### PR TITLE
Fix regex to allow spaces and punctuation in bold text.

### DIFF
--- a/lib/email_processor.rb
+++ b/lib/email_processor.rb
@@ -43,7 +43,7 @@ class EmailProcessor
         @body.gsub!(/\n\n\n/, "\n\n \n\n") #allow double line breaks
         @body = unfold_paragraphs(@body) unless @from.include?("yahoo.com") #fix wrapped plain text, but yahoo messes this up
         @body = ActionController::Base.helpers.simple_format(@body) #format the email body coming in to basic HTML
-        @body.gsub!(/\*(.*?)\*/i, '<b>\1</b>') #bold when bold needed
+        @body.gsub!(/\*(.+?)\*/i, '<b>\1</b>') #bold when bold needed
         @body.gsub!(/\[image\:\ Inline\ image\ [0-9]{1,2}\]/, "") #remove "inline image" text
 
         date = parse_subject_for_date(@subject, user)


### PR DESCRIPTION
This should allow stuff like _Bold:_ or even *Bold: *, while remaining non-greedy. Haven't tested it.
