### PR TITLE
Allow 4 years ago leap entry even when way back entries are turned off

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,15 +62,15 @@ class User < ActiveRecord::Base
     if entry_date.present?
       entry_date = Date.parse(entry_date.to_s)
 
-      if way_back_past_entries && Date.leap?(entry_date.year) && entry_date.month == 2 && entry_date.day == 29 && leap_year_entry = random_entries.where(date: entry_date - 4.years).first
-        leap_year_entry
-      elsif way_back_past_entries && (exact_years_back_entry = random_entries.where('extract(month from date) = ? AND extract(day from date) = ? AND extract(year from date) != ?', entry_date.month, entry_date.day, entry_date.year).sample)
+      if way_back_past_entries && (exact_years_back_entry = random_entries.where('extract(month from date) = ? AND extract(day from date) = ? AND extract(year from date) != ?', entry_date.month, entry_date.day, entry_date.year).sample)
         exact_years_back_entry
+      elsif !way_back_past_entries && Date.leap?(entry_date.year) && entry_date.month == 2 && entry_date.day == 29 && leap_year_entry = random_entries.where(date: entry_date - 4.years).first
+        leap_year_entry
       elsif !way_back_past_entries && (exactly_last_year_entry = random_entries.where(date: entry_date.last_year).first)
         exactly_last_year_entry
       elsif (emails_sent % 3 == 0) && (exactly_30_days_ago = random_entries.where(date: entry_date.last_month).first)
         exactly_30_days_ago
-      elsif !way_back_past_entries && (emails_sent % 5 == 0) && (exactly_7_days_ago = random_entries.where(date: entry_date - 7.days).first)
+      elsif (emails_sent % 5 == 0) && (exactly_7_days_ago = random_entries.where(date: entry_date - 7.days).first)
         exactly_7_days_ago        
       elsif way_back_past_entries && (emails_sent % 2 == 0) && random_entries.where('date < (?)', entry_date.last_year).count > 30
         random_entries.where('date < (?)', entry_date.last_year).sample #grab entry way back


### PR DESCRIPTION
The purpose of turning off way back entries was to consistently give you
the most recent entry with the same date (usually 1 year ago) as opposed to
a random entry with the same date (X years ago). Even though the text of the
option is "include past entries that are over a year old", it makes sense for
2/29 to be an exception.

So the new logic should read:
- if way back entries, pick a random entry with the same date, if one exists. On 2/29 if you have way back entries turned on, it'll pick a random previous leap day.
- if way back entries are off but it's 2/29, pick exactly 4 years ago if possible.
- if way back entries are off, pick exactly 1 year ago, if possible.
...

While in there, I also removed the way back entries condition on the exactly 1 week ago case, because it didn't seem it should apply.