### PR TITLE
Fix typos and controller specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ STRIPE_SIGNING_SECRET: whsec_1234
 
 ### Things you may want to rip out
 
-You can opt to not use Turnstile and Clarafai: simply don't add an environment variables for `TURNSTILE_SITE_KEY`, `CLARIFAI_V2_API_KEY`.
+You can opt to not use Turnstile and Clarifai: simply don't add an environment variables for `TURNSTILE_SITE_KEY`, `CLARIFAI_PERSONAL_ACCESS_TOKEN`.
 
 
 ### Tests

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -96,7 +96,7 @@ class EntriesController < ApplicationController
 
   def create
     if current_user.is_free?
-      flash[:alert] = "<a href='#{subscribe_url}'' class='alert-link'>Subscribe to PRO</a> to write new entries.".html_safe
+      flash[:alert] = "<a href='#{subscribe_url}' class='alert-link'>Subscribe to PRO</a> to write new entries.".html_safe
       redirect_to root_path and return
     end
 
@@ -228,7 +228,7 @@ class EntriesController < ApplicationController
 
   def destroy
     if current_user.is_free?
-      flash[:alert] = "<a href='#{subscribe_url}'' class='alert-link'>Subscribe to PRO</a> to edit entries.".html_safe
+      flash[:alert] = "<a href='#{subscribe_url}' class='alert-link'>Subscribe to PRO</a> to edit entries.".html_safe
       redirect_to root_path and return
     end
 

--- a/spec/controllers/entries_controller_spec.rb
+++ b/spec/controllers/entries_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EntriesController, type: :controller do
       get :index
       expect(response.status).to eq 200
       expect(response.body).to have_content(entry.formatted_body)
-      expect(response.body).to_not have_content(not_my_entry.formatted_body)
+      expect(response.body).not_to have_content(not_my_entry.formatted_body)
     end
   end
 
@@ -66,14 +66,14 @@ RSpec.describe EntriesController, type: :controller do
     end
 
     it 'should redirect to sign in if not logged in' do
-      expect { post :create, params: params }.to_not change { Entry.count }
+      expect { post :create, params: params }.not_to change { Entry.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(new_user_session_url)
     end
 
     it 'should not let me create an entry if free user' do
       sign_in user
-      expect { post :create, params: params }.to_not change { Entry.count }
+      expect { post :create, params: params }.not_to change { Entry.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(root_path)
     end
@@ -97,7 +97,7 @@ RSpec.describe EntriesController, type: :controller do
 
     it "should not delete entries unless user is pro" do
       sign_in user
-      expect { delete :destroy, params: { id: not_my_entry.id } }.to_not change { Entry.count }
+      expect { delete :destroy, params: { id: not_my_entry.id } }.not_to change { Entry.count }
     end
 
     it 'should delete pro user entries' do
@@ -109,7 +109,7 @@ RSpec.describe EntriesController, type: :controller do
 
     it "should not delete entries that are not the user's" do
       sign_in user
-      expect { delete :destroy, params: { id: not_my_entry.id } }.to_not change { Entry.count }
+      expect { delete :destroy, params: { id: not_my_entry.id } }.not_to change { Entry.count }
     end
   end
 
@@ -140,7 +140,7 @@ RSpec.describe EntriesController, type: :controller do
       get :latest
       expect(response.status).to eq 200
       expect(response.body).to have_content(entry.formatted_body)
-      expect(response.body).to_not have_content(not_my_entry.formatted_body)
+      expect(response.body).not_to have_content(not_my_entry.formatted_body)
     end
 
     it 'should show a CTA to logged in users without entries' do
@@ -166,7 +166,7 @@ RSpec.describe EntriesController, type: :controller do
       get :export, format: 'txt'
       expect(response.status).to eq 200
       expect(response.body).to have_content(entry.formatted_body)
-      expect(response.body).to_not have_content(not_my_entry.formatted_body)
+      expect(response.body).not_to have_content(not_my_entry.formatted_body)
     end
   end
 end

--- a/spec/controllers/entries_controller_spec.rb
+++ b/spec/controllers/entries_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe EntriesController, type: :controller do
     end
 
     it 'should redirect to sign in if not logged in' do
-      post :create, params: params
+      expect { post :create, params: params }.to_not change { Entry.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(new_user_session_url)
     end

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -96,21 +96,20 @@ RSpec.describe PaymentsController, type: :controller do
     end
 
     it 'should redirect to login url if not logged in' do
-      expect { post :create, params: params }.to_not change { Payment.count }
+      post :create, params: params
       expect(response.status).to eq 302
       expect(response).to redirect_to(new_user_session_url)
     end
 
     it 'should redirect to past entries path if not superuser' do
       sign_in user
-      expect { post :create, params: params }.to_not change { Payment.count }
+      post :create, params: params
       expect(response.status).to eq 302
       expect(response).to redirect_to(entries_path)
     end
 
     it 'should show create new Payment for superusers' do
       sign_in superuser
-      post :create, params: params
       expect { post(:create, params: params) }.to change { Payment.count }.by(1)
       expect(response.status).to eq 302
       expect(response).to redirect_to(payments_url)

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -96,14 +96,14 @@ RSpec.describe PaymentsController, type: :controller do
     end
 
     it 'should redirect to login url if not logged in' do
-      expect { post :create, params: params }.to_not change { Payment.count }
+      expect { post :create, params: params }.not_to change { Payment.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(new_user_session_url)
     end
 
     it 'should redirect to past entries path if not superuser' do
       sign_in user
-      expect { post :create, params: params }.to_not change { Payment.count }
+      expect { post :create, params: params }.not_to change { Payment.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(entries_path)
     end
@@ -118,14 +118,14 @@ RSpec.describe PaymentsController, type: :controller do
 
   describe 'destroy' do
     it 'should redirect to login url if not logged in' do
-      expect { delete(:destroy, params: { id: payment.id }) }.to_not change { Payment.count }
+      expect { delete(:destroy, params: { id: payment.id }) }.not_to change { Payment.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(new_user_session_url)
     end
 
     it 'should redirect to past entries path if not superuser' do
       sign_in user
-      expect { delete(:destroy, params: { id: payment.id }) }.to_not change { Payment.count }
+      expect { delete(:destroy, params: { id: payment.id }) }.not_to change { Payment.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(entries_path)
     end
@@ -168,7 +168,7 @@ RSpec.describe PaymentsController, type: :controller do
 
     it 'should create a payment but not change plan or email user thanks' do
       payhere_params.deep_merge!(customer: { id: paid_annual_user.payhere_id })
-      expect { post :payment_notify, params: payhere_params, as: :json }.to_not change {
+      expect { post :payment_notify, params: payhere_params, as: :json }.not_to change {
         paid_annual_user.reload.plan
       }
       expect(ActionMailer::Base.deliveries.size).to eq 0
@@ -193,7 +193,7 @@ RSpec.describe PaymentsController, type: :controller do
 
     it 'should not create a payment if no match' do
       payhere_params.deep_merge!(customer: { id: 999999999999, email: "fakeemail@fake.com" })
-      expect { post :payment_notify, params: payhere_params, as: :json }.to_not change { Payment.count }
+      expect { post :payment_notify, params: payhere_params, as: :json }.not_to change { Payment.count }
       expect(paid_user.reload.plan).to eq paid_user.plan
       expect(ActionMailer::Base.deliveries.last.subject).to eq '[REFUND REQUIRED] Payment Without a User'
     end
@@ -237,7 +237,7 @@ RSpec.describe PaymentsController, type: :controller do
 
     it 'should not create a payment if no match' do
       gumroad_params.merge!(email: Faker::Internet.email, purchaser_id: Faker::Number.number(digits: 12))
-      expect { post :payment_notify, params: gumroad_params, as: :json }.to_not change { Payment.count }
+      expect { post :payment_notify, params: gumroad_params, as: :json }.not_to change { Payment.count }
       expect(paid_user.reload.plan).to eq paid_user.plan
       expect(ActionMailer::Base.deliveries.last.subject).to eq '[REFUND REQUIRED] Payment Without a User'
     end
@@ -261,7 +261,7 @@ RSpec.describe PaymentsController, type: :controller do
 
     it 'should not create a payment if no match' do
       paypal_params.merge!(payer_email: paid_user.email, item_name: 'Dabble Me PRO for WRONG_KEY')
-      expect { post :payment_notify, params: paypal_params, as: :json }.to_not change { Payment.count }
+      expect { post :payment_notify, params: paypal_params, as: :json }.not_to change { Payment.count }
       expect(paid_user.reload.plan).to eq paid_user.plan
       expect(ActionMailer::Base.deliveries.last.subject).to eq '[REFUND REQUIRED] Payment Without a User'
     end

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -96,14 +96,14 @@ RSpec.describe PaymentsController, type: :controller do
     end
 
     it 'should redirect to login url if not logged in' do
-      post :create, params: params
+      expect { post :create, params: params }.to_not change { Payment.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(new_user_session_url)
     end
 
     it 'should redirect to past entries path if not superuser' do
       sign_in user
-      post :create, params: params
+      expect { post :create, params: params }.to_not change { Payment.count }
       expect(response.status).to eq 302
       expect(response).to redirect_to(entries_path)
     end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe RegistrationsController, type: :controller do
       expect(response.status).to eq 302
       expect(response).to redirect_to(edit_user_registration_url)
       expect(paid_user.reload.email).to eq email
-      expect(paid_user.encrypted_password).to_not eq old_password
+      expect(paid_user.encrypted_password).not_to eq old_password
     end
 
     it 'should not allow user updates to frequency for free users' do

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -34,7 +34,7 @@ describe 'Day Entries' do
     it 'should not show me other users entries' do
       sign_in user
       visit group_entries_url(group: not_my_entry.id)
-      expect(page).to_not have_content not_my_entry.body
+      expect(page).not_to have_content not_my_entry.body
     end
 
     it 'should not show me other users entries in edit mode' do

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Pages' do
   include_context 'has all objects'
 
-  it 'has corect title for Root page' do
+  it 'has correct title for Root page' do
     visit root_path
     expect(page).to have_title 'Dabble Me — Your private journal.'
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -69,7 +69,7 @@ describe User do
       entry_date = Date.parse("2019-10-5")
       user.entries.create(date: Date.parse("2016-1-15"), body: "Hi from way back.")
       user.entries.create(date: Date.parse("2018-10-3"), body: "Hi from a few days ago.")
-      expect(user.random_entry(entry_date).date.year).to_not eq(2015)
+      expect(user.random_entry(entry_date).date.year).not_to eq(2015)
     end
 
   end


### PR DESCRIPTION
## Summary
- fix typo in welcome spec
- fix stray quote in subscription flash messages
- clarify Clarifai env var in README
- remove redundant POST and update create tests in payments controller spec

## Testing
- `bundle exec rspec spec/features/welcome_spec.rb -fd`
- `bundle exec rspec spec/controllers/entries_controller_spec.rb -fd`
- `bundle exec rspec spec/controllers/payments_controller_spec.rb -fd`


------
https://chatgpt.com/codex/tasks/task_e_68409b0f5d988332a71b94012787df15