### PR TITLE
Fix Ruby 3.4 footer syntax and validate local dev setup

### DIFF
--- a/app/views/shared/_marketing_footer.html.erb
+++ b/app/views/shared/_marketing_footer.html.erb
@@ -8,13 +8,13 @@
         <div>
           <ul role="list" class="mt-4 space-y-3">
             <li>
-              <a href="<%= root_path((s: user_signed_in? ? "0" : nil)) %>" class="text-sm text-muted hover:text-primary transition-colors">Home</a>
+              <a href="<%= root_path(s: (user_signed_in? ? '0' : nil)) %>" class="text-sm text-muted hover:text-primary transition-colors">Home</a>
             </li>
             <li>
-              <a href="<%= root_path((s: user_signed_in? ? "0" : nil), anchor: "features") %>" class="text-sm text-muted hover:text-primary transition-colors">Features</a>
+              <a href="<%= root_path(s: (user_signed_in? ? '0' : nil), anchor: 'features') %>" class="text-sm text-muted hover:text-primary transition-colors">Features</a>
             </li>
             <li>
-              <a href="<%= root_path((s: user_signed_in? ? "0" : nil), anchor: "pricing") %>" class="text-sm text-muted hover:text-primary transition-colors">Pricing</a>
+              <a href="<%= root_path(s: (user_signed_in? ? '0' : nil), anchor: 'pricing') %>" class="text-sm text-muted hover:text-primary transition-colors">Pricing</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix Ruby 3.4 parsing error in `app/views/shared/_marketing_footer.html.erb` by updating `root_path` keyword-arg usage
- set up local dev environment in cloud VM (asdf for Ruby/Node, bundle install, npm install)
- install/start PostgreSQL + Redis, prepare DB, build Tailwind CSS, and run Puma on port 3000
- update `AGENTS.md` to standardize asdf shell initialization and cloud-safe service startup commands

## Validation
- service and runtime checks captured in `/opt/cursor/artifacts/env_checks.log`
- asdf/bundler checks captured in `/opt/cursor/artifacts/asdf_bundle_verification.log`
- browser walkthrough confirms landing page loads, login works with seeded admin credentials, and authenticated dashboard renders

## Walkthrough Artifacts
[dabbleme_env_setup_and_login_demo.mp4](https://cursor.com/agents/bc-da48c273-7c6f-45d7-b6ea-971379d26bd4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdabbleme_env_setup_and_login_demo.mp4)
![Landing page](https://cursor.com/artifacts/c/art-f2df2ac1-89c1-4aaf-a56a-b53eeb873f11)
![Authenticated dashboard](https://cursor.com/artifacts/c/art-4154da56-f2cf-4057-9371-5918a988ee66)
[env_checks.log](https://cursor.com/artifacts/c/art-a659aaf7-fe28-48e2-89ad-144d2ac98c85)
[asdf_bundle_verification.log](https://cursor.com/artifacts/c/art-6f58387e-b4d2-45e8-922b-10d619927b09)

## Notes
- Puma is running in tmux session `dabbleme-puma` for continued manual testing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da48c273-7c6f-45d7-b6ea-971379d26bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da48c273-7c6f-45d7-b6ea-971379d26bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

