### PR TITLE
Add entry link to MCP create responses

### DIFF
--- a/app/lib/mcp/tools/helpers.rb
+++ b/app/lib/mcp/tools/helpers.rb
@@ -42,6 +42,13 @@ module Mcp
         tz = ActiveSupport::TimeZone[user.send_timezone] || Time.zone
         Time.current.in_time_zone(tz).to_date.iso8601
       end
+
+      def entry_public_url(entry_or_date)
+        date = entry_or_date.respond_to?(:date) ? entry_or_date.date : entry_or_date
+        date = date.to_date
+
+        "#{ApplicationHelper.site_public_base_url}/entries/#{date.year}/#{date.month}/#{date.day}"
+      end
     end
   end
 end

--- a/app/services/mcp/entry_creator.rb
+++ b/app/services/mcp/entry_creator.rb
@@ -340,6 +340,7 @@ module Mcp
       {
         id: entry.id,
         date: entry.date.to_date.iso8601,
+        url: Tools::Helpers.entry_public_url(entry),
         excerpt: entry.text_body.to_s.squish.truncate(5000),
         hashtags: entry.hashtags,
         has_image: entry.image.present?

--- a/script/mcp_inspector_smoke.sh
+++ b/script/mcp_inspector_smoke.sh
@@ -99,7 +99,7 @@ echo "==> MCP Inspector: tools/call analyze_entries"
 "${INSPECTOR[@]}" --method tools/call --tool-name analyze_entries | ruby -rjson -e 'j=JSON.parse(STDIN.read); t=j.dig("content",0,"text"); abort("analyze") unless t.include?("total_entries"); puts "ok"'
 
 echo "==> MCP Inspector: tools/call create_entry (2099-06-20)"
-"${INSPECTOR[@]}" --method tools/call --tool-name create_entry --tool-arg date=2099-06-20 --tool-arg body="MCP inspector smoke" | ruby -rjson -e 'j=JSON.parse(STDIN.read); t=j.dig("content",0,"text"); abort("create") unless t.include?("\"success\": true") || t.include?("\"success\":true"); puts "ok"'
+"${INSPECTOR[@]}" --method tools/call --tool-name create_entry --tool-arg date=2099-06-20 --tool-arg body="MCP inspector smoke" | ruby -rjson -e 'j=JSON.parse(STDIN.read); text=JSON.parse(j.dig("content",0,"text")); url=text.dig("entry","url").to_s; abort("create") unless text["success"] == true && url.end_with?("/entries/2099/6/20"); puts "ok"'
 
 echo "==> MCP Inspector: resources/list (expect empty or protocol-compliant)"
 set +e

--- a/spec/controllers/mcp_controller_spec.rb
+++ b/spec/controllers/mcp_controller_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe McpController, type: :controller do
         structured = JSON.parse(response.body).dig("result", "structuredContent")
         expect(structured["success"]).to eq(true)
         expect(structured["entry"]["date"]).to eq("2030-01-15")
+        expect(structured["entry"]["url"]).to eq("http://test.host/entries/2030/1/15")
       end
 
       it "creates a new entry on an unused date" do
@@ -142,6 +143,7 @@ RSpec.describe McpController, type: :controller do
         expect(structured["success"]).to eq(true)
         expect(structured["merged"]).to eq(false)
         expect(structured["entry"]["date"]).to eq("2099-06-15")
+        expect(structured["entry"]["url"]).to eq("http://test.host/entries/2099/6/15")
 
         created = paid_user.entries.find(structured["entry"]["id"])
         expect(created.body).to include("<p>Line one.</p>")

--- a/spec/controllers/mcp_controller_spec.rb
+++ b/spec/controllers/mcp_controller_spec.rb
@@ -98,6 +98,8 @@ RSpec.describe McpController, type: :controller do
       end
 
       it "defaults date to today in the user timezone when omitted" do
+        expected_url = Mcp::Tools::Helpers.entry_public_url(Date.new(2030, 1, 15))
+
         denver = ActiveSupport::TimeZone["America/Denver"]
         travel_to denver.local(2030, 1, 15, 14, 0, 0) do
           paid_user.update!(send_timezone: "America/Denver")
@@ -120,10 +122,12 @@ RSpec.describe McpController, type: :controller do
         structured = JSON.parse(response.body).dig("result", "structuredContent")
         expect(structured["success"]).to eq(true)
         expect(structured["entry"]["date"]).to eq("2030-01-15")
-        expect(structured["entry"]["url"]).to eq("http://test.host/entries/2030/1/15")
+        expect(structured["entry"]["url"]).to eq(expected_url)
       end
 
       it "creates a new entry on an unused date" do
+        expected_url = Mcp::Tools::Helpers.entry_public_url(Date.new(2099, 6, 15))
+
         post :invoke, params: {
           jsonrpc: "2.0",
           id: 31,
@@ -143,7 +147,7 @@ RSpec.describe McpController, type: :controller do
         expect(structured["success"]).to eq(true)
         expect(structured["merged"]).to eq(false)
         expect(structured["entry"]["date"]).to eq("2099-06-15")
-        expect(structured["entry"]["url"]).to eq("http://test.host/entries/2099/6/15")
+        expect(structured["entry"]["url"]).to eq(expected_url)
 
         created = paid_user.entries.find(structured["entry"]["id"])
         expect(created.body).to include("<p>Line one.</p>")

--- a/spec/services/mcp/entry_creator_spec.rb
+++ b/spec/services/mcp/entry_creator_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Mcp::EntryCreator do
       entry = paid_user.entries.find(result[:entry][:id])
       expect(entry.image).to be_present
       expect(entry.body).to include("with photo")
+      expect(result[:entry][:url]).to eq("http://[REDACTED]/entries/2099/1/10")
     end
 
     it "accepts a data-URL image_base64 without body text" do
@@ -97,6 +98,7 @@ RSpec.describe Mcp::EntryCreator do
 
       expect(result[:success]).to eq(true)
       expect(result[:entry][:has_image]).to eq(true)
+      expect(result[:entry][:url]).to eq("http://[REDACTED]/entries/2099/1/11")
     end
   end
 end

--- a/spec/services/mcp/entry_creator_spec.rb
+++ b/spec/services/mcp/entry_creator_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Mcp::EntryCreator do
   include_context "has all objects"
 
+  def expected_entry_url(date)
+    "#{ApplicationHelper.site_public_base_url}/entries/#{date.year}/#{date.month}/#{date.day}"
+  end
+
   before do
     # CI sets AWS_BUCKET=test (see .github/workflows/test.yml); dev machines may use dabble-me from local_env.yml.
     # Stub whatever host/path Fog uses for this app's configured bucket (virtual-hosted and path-style S3 URLs).
@@ -83,7 +87,7 @@ RSpec.describe Mcp::EntryCreator do
       entry = paid_user.entries.find(result[:entry][:id])
       expect(entry.image).to be_present
       expect(entry.body).to include("with photo")
-      expect(result[:entry][:url]).to eq("http://[REDACTED]/entries/2099/1/10")
+      expect(result[:entry][:url]).to eq(expected_entry_url(Date.new(2099, 1, 10)))
     end
 
     it "accepts a data-URL image_base64 without body text" do
@@ -98,7 +102,7 @@ RSpec.describe Mcp::EntryCreator do
 
       expect(result[:success]).to eq(true)
       expect(result[:entry][:has_image]).to eq(true)
-      expect(result[:entry][:url]).to eq("http://[REDACTED]/entries/2099/1/11")
+      expect(result[:entry][:url]).to eq(expected_entry_url(Date.new(2099, 1, 11)))
     end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add the canonical public entry URL to MCP `create_entry` responses
- cover the new response field in controller and service specs using the same public-base helper as production
- tighten the MCP Inspector smoke script to assert the returned link format end-to-end
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cb34c62-5a74-4f5a-a4e0-aa83a3680f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cb34c62-5a74-4f5a-a4e0-aa83a3680f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

