### PR TITLE
Allow cancelling scheduled account deletion on sign-in

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -63,7 +63,7 @@ class RegistrationsController < Devise::RegistrationsController
     if current_user.valid_password?(params[:user][:current_password])
       schedule_user_deletion
       sign_out current_user
-      redirect_to root_path, notice: "Your account will be permanently deleted in 1 hour. Contact support if you change your mind: hello@#{ENV['MAIN_DOMAIN']}"
+      redirect_to root_path, notice: "Your account will be permanently deleted in 1 hour. Sign back in before then to cancel deletion."
     else
       flash[:alert] = "Incorrect current password."
       redirect_to delete_account_path
@@ -119,17 +119,8 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def schedule_user_deletion
-    cancel_stripe_subscription
     current_user.update_column(:deleted_at, Time.current)
     DeleteUserJob.set(wait: 1.hour).perform_later(current_user.id)
-  end
-
-  def cancel_stripe_subscription
-    return unless current_user.stripe_id.present?
-
-    Stripe::Subscription.list(customer: current_user.stripe_id).auto_paging_each(&:cancel)
-  rescue Stripe::InvalidRequestError => e
-    Sentry.capture_exception(e, extra: { user_id: current_user.id, stripe_id: current_user.stripe_id })
   end
 
   def check_captcha

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -13,14 +13,7 @@ class DeleteUserJob < ActiveJob::Base
     payhere_id = user.payhere_id
     stripe_id = user.stripe_id
 
-    # Cancel Stripe subscription (should already be cancelled, but ensures cleanup)
-    if stripe_id.present?
-      begin
-        Stripe::Subscription.list(customer: stripe_id).auto_paging_each(&:cancel)
-      rescue Stripe::InvalidRequestError
-        # Already cancelled or customer doesn't exist - that's fine
-      end
-    end
+    cancel_stripe_subscriptions(stripe_id)
 
     # Destroy entries in batches to avoid memory issues and trigger CarrierWave cleanup
     Entry.where(user_id: user_id).find_each(batch_size: 100, &:destroy)
@@ -42,5 +35,15 @@ class DeleteUserJob < ActiveJob::Base
         deleted_at: user.deleted_at
       })
     end
+  end
+
+  private
+
+  def cancel_stripe_subscriptions(stripe_id)
+    return if stripe_id.blank?
+
+    Stripe::Subscription.list(customer: stripe_id).auto_paging_each(&:cancel)
+  rescue Stripe::InvalidRequestError => e
+    Sentry.capture_exception(e, extra: { stripe_id: stripe_id })
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,14 +121,11 @@ class User < ActiveRecord::Base
     deleted_at.present?
   end
 
-  # Devise: prevent login if account is pending deletion
-  def active_for_authentication?
-    super && !deletion_pending?
-  end
+  def cancel_pending_deletion!
+    return false unless deletion_pending?
 
-  # Devise: custom message for pending deletion
-  def inactive_message
-    deletion_pending? ? :account_pending_deletion : super
+    update_column(:deleted_at, nil)
+    true
   end
 
   def is_pro?

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -291,3 +291,9 @@ Devise.setup do |config|
   #config.otp_controller_path = 'devise'
 
 end
+
+Warden::Manager.after_authentication do |user, auth, _opts|
+  next unless user.is_a?(User) && user.cancel_pending_deletion!
+
+  auth.request.flash[:notice] = I18n.t('devise.sessions.deletion_cancelled')
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -7,7 +7,6 @@ en:
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      account_pending_deletion: "Your account is scheduled for deletion."
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
       invalid: "Invalid email or password."
@@ -43,6 +42,7 @@ en:
       updated: "Your account has been updated successfully."
     sessions:
       signed_in: ""
+      deletion_cancelled: "Account deletion cancelled. Welcome back."
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
     unlocks:

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -216,6 +216,7 @@ RSpec.describe RegistrationsController, type: :controller do
       end.to have_enqueued_job(DeleteUserJob).with(user.id)
       expect(user.reload.deleted_at).to be_present
       expect(response).to redirect_to(root_path)
+      expect(flash[:notice]).to include('Sign back in before then to cancel deletion')
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :controller do
+  include_context 'has all objects'
+
+  before do
+    request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  describe 'create' do
+    it 'cancels pending deletion when the user signs in' do
+      user.update_column(:deleted_at, Time.current)
+
+      post :create, params: { user: { email: user.email, password: user.password } }
+
+      expect(user.reload.deleted_at).to be_nil
+      expect(flash[:notice]).to eq(I18n.t('devise.sessions.deletion_cancelled'))
+    end
+  end
+end

--- a/spec/jobs/delete_user_job_spec.rb
+++ b/spec/jobs/delete_user_job_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe DeleteUserJob, type: :job do
+  include_context 'has all objects'
+
+  it 'does not delete the user when deletion was cancelled' do
+    expect do
+      described_class.perform_now(user.id)
+    end.not_to change(User, :count)
+
+    expect(user.reload).to be_persisted
+  end
+
+  it 'deletes the user when deletion is still pending' do
+    user.update_column(:deleted_at, Time.current)
+
+    expect do
+      described_class.perform_now(user.id)
+    end.to change(User, :count).by(-1)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -124,6 +124,18 @@ describe User do
     end
   end
 
+  describe '#cancel_pending_deletion!' do
+    it 'clears deleted_at when deletion is pending' do
+      user.update_column(:deleted_at, Time.current)
+      expect(user.cancel_pending_deletion!).to eq(true)
+      expect(user.reload.deleted_at).to be_nil
+    end
+
+    it 'returns false when deletion is not pending' do
+      expect(user.cancel_pending_deletion!).to eq(false)
+    end
+  end
+
   describe '#send_devise_notification' do
     around do |example|
       previous_adapter = ActiveJob::Base.queue_adapter


### PR DESCRIPTION
## Summary
- Users who schedule account deletion can cancel it by signing back in within the one-hour grace period (`deleted_at` is cleared; `DeleteUserJob` no-ops).
- Stripe subscriptions are cancelled only when `DeleteUserJob` actually runs, not when deletion is first scheduled.
- Updated deletion notice to tell users they can sign back in to cancel.

## Test plan
- [ ] Schedule account deletion, sign back in with password — account remains, flash shows cancellation message
- [ ] Schedule deletion, wait for job (or run `DeleteUserJob` in console) — user and entries removed, Stripe cancelled if applicable
- [ ] Schedule deletion, sign back in with passkey — same cancellation behavior
- [ ] `bundle exec rspec spec/jobs/delete_user_job_spec.rb spec/controllers/sessions_controller_spec.rb spec/controllers/registrations_controller_spec.rb -e destroy`

Made with [Cursor](https://cursor.com)