### PR TITLE
Fix sideways phone photos in collages

### DIFF
--- a/app/services/collage_generator.rb
+++ b/app/services/collage_generator.rb
@@ -221,7 +221,7 @@ class CollageGenerator
     data = fetch_bytes(url)
     return nil unless data
 
-    img = decode_image(data)
+    img = orient_image(decode_image(data))
     # `new_from_buffer` can succeed lazily then fail mid-pipeline (truncated HEIC,
     # seek errors). Materialize while we still know the URL for logging.
     img.copy_memory
@@ -241,6 +241,14 @@ class CollageGenerator
     Vips::Image.new_from_buffer(data, "", fail_on: :none)
   rescue ArgumentError
     Vips::Image.new_from_buffer(data, "", fail: false)
+  end
+
+  # Phone JPEGs/HEIC often store pixels on the side and rely on EXIF orientation.
+  # Browsers respect that tag; libvips does not unless we autorot explicitly.
+  def orient_image(image)
+    image.autorot
+  rescue Vips::Error
+    image
   end
 
   # Downloads the URL body using Net::HTTP directly. We avoid open-uri because

--- a/spec/services/collage_generator_spec.rb
+++ b/spec/services/collage_generator_spec.rb
@@ -31,6 +31,25 @@ RSpec.describe CollageGenerator do
       expect(ordered[2, 3]).to contain_exactly(land, port, port)
     end
 
+    it "applies EXIF orientation via autorot" do
+      gen = described_class.new(urls: [])
+      img = Vips::Image.black(100, 200, bands: 3)
+
+      oriented = gen.send(:orient_image, img)
+
+      expect(oriented).to be_a(Vips::Image)
+      expect(oriented.width).to eq(100)
+      expect(oriented.height).to eq(200)
+    end
+
+    it "returns the original image when autorot fails" do
+      gen = described_class.new(urls: [])
+      img = Vips::Image.black(10, 20, bands: 3)
+      allow(img).to receive(:autorot).and_raise(Vips::Error, "autorot failed")
+
+      expect(gen.send(:orient_image, img)).to eq(img)
+    end
+
     it "fits each tile to the cell without cropping (letterbox), exact output size" do
       gen = described_class.new(urls: [])
       # Wide source in a square cell → scaled down, vertical padding.


### PR DESCRIPTION
## Summary
- Apply libvips `autorot` after decoding each collage source image so EXIF orientation from phone JPEGs/HEIC is respected.
- Collage tiles were sometimes sideways because libvips loads raw pixel data without applying the orientation tag browsers use automatically.

## Test plan
- [ ] Attach phone photos (portrait/landscape) to an entry via email or web and confirm collage tiles are upright
- [ ] `bundle exec rspec spec/services/collage_generator_spec.rb`

Made with [Cursor](https://cursor.com)