### PR TITLE
Improve Mailgun collage lookup and add failure diagnostics

### DIFF
--- a/app/jobs/image_collage_job.rb
+++ b/app/jobs/image_collage_job.rb
@@ -55,7 +55,10 @@ class ImageCollageJob < ActiveJob::Base
         ['The images could not be generated or saved after several attempts. Please try uploading again via the web interface.']
       end
       Sentry.set_user(id: @user.id, email: @user.email)
-      Sentry.capture_message("Error updating collage image", level: :info, extra: { entry_id: entry_id, error_messages: error_messages, url: collage_url })
+      sentry_extra = { entry_id: entry_id, error_messages: error_messages, url: collage_url }
+      sentry_extra[:mailgun_lookup_attempts] = @mailgun_event_lookup_log if @mailgun_event_lookup_log.present?
+      sentry_extra[:message_id] = @message_id if @message_id.present?
+      Sentry.capture_message("Error updating collage image", level: :info, extra: sentry_extra)
       # Persist the error on the entry so the logged-in user sees a banner on
       # their next page view. The job runs async after the request is gone,
       # so we can't use `flash` — the entry itself is the durable channel.
@@ -100,24 +103,12 @@ class ImageCollageJob < ActiveJob::Base
     @error = "No message ID found" unless @message_id.present?
     return unless @message_id.present?
 
-    last_message = nil
-    message = nil
-    5.times do |attempt|
-      connection = Faraday.new(url: "https://api.mailgun.net") do |f|
-        f.request :json
-        f.response :json
-        f.request :authorization, :basic, 'api', ENV['MAILGUN_API_KEY']
-        f.options.timeout = 120
-        f.options.open_timeout = 120
-      end
-      resp = connection.get("/v3/#{ENV['SMTP_DOMAIN']}/events?pretty=yes&event=accepted&ascending=no&limit=1&message-id=#{URI.encode_www_form_component(@message_id)}")
-      last_message = resp.body&.dig("items", 0) if resp.success?
-      break if last_message.present?
-
-      sleep(10 * (2**attempt)) if attempt < 4
+    last_message, @mailgun_event_lookup_log = fetch_mailgun_stored_event
+    unless last_message.present?
+      @error = "No last message found"
+      log_mailgun_event_lookup_failure
+      return
     end
-    @error = "No last message found" unless last_message.present?
-    return unless last_message.present?
 
     message = nil
     5.times do |attempt|
@@ -200,6 +191,83 @@ class ImageCollageJob < ActiveJob::Base
   end
 
   private
+
+  # Inbound multi-attachment emails are indexed as `stored` events; `accepted` is
+  # primarily outbound. Try both (and unfiltered) with/without angle brackets.
+  def fetch_mailgun_stored_event
+    lookup_log = []
+
+    5.times do |attempt|
+      mailgun_message_id_variants.each do |message_id|
+        %w[stored accepted].each do |event|
+          item, resp = mailgun_events_lookup(message_id: message_id, event: event)
+          lookup_log << mailgun_lookup_attempt(attempt, message_id, event, resp, item)
+          return [item, lookup_log] if item.present?
+        end
+
+        item, resp = mailgun_events_lookup(message_id: message_id)
+        lookup_log << mailgun_lookup_attempt(attempt, message_id, nil, resp, item)
+        return [item, lookup_log] if item.present?
+      end
+
+      sleep(10 * (2**attempt)) if attempt < 4
+    end
+
+    [nil, lookup_log]
+  end
+
+  def mailgun_message_id_variants
+    [@message_id, "<#{@message_id}>"].uniq
+  end
+
+  def mailgun_events_connection
+    @mailgun_events_connection ||= Faraday.new(url: "https://api.mailgun.net") do |f|
+      f.request :json
+      f.response :json
+      f.request :authorization, :basic, 'api', ENV['MAILGUN_API_KEY']
+      f.options.timeout = 120
+      f.options.open_timeout = 120
+    end
+  end
+
+  def mailgun_events_lookup(message_id:, event: nil)
+    params = {
+      pretty: 'yes',
+      ascending: 'no',
+      limit: 1,
+      'message-id': message_id
+    }
+    params[:event] = event if event.present?
+    query = params.map { |key, value| "#{key}=#{URI.encode_www_form_component(value)}" }.join('&')
+    resp = mailgun_events_connection.get("/v3/#{ENV['SMTP_DOMAIN']}/events?#{query}")
+    item = resp.body&.dig('items', 0) if resp.success?
+    [item, resp]
+  end
+
+  def mailgun_lookup_attempt(attempt, message_id, event, resp, item)
+    {
+      attempt: attempt,
+      message_id: message_id,
+      event: event,
+      status: resp.status,
+      items_count: resp.body.is_a?(Hash) ? resp.body['items']&.size : nil,
+      error: resp.body.is_a?(Hash) ? resp.body['error'] : nil,
+      found_storage_url: item&.dig('storage', 'url').present?
+    }
+  end
+
+  def log_mailgun_event_lookup_failure
+    Sentry.capture_message(
+      'Mailgun events lookup failed for collage attachments',
+      level: :warning,
+      extra: {
+        entry_user_id: @user&.id,
+        message_id: @message_id,
+        smtp_domain: ENV['SMTP_DOMAIN'],
+        lookup_attempts: @mailgun_event_lookup_log
+      }
+    )
+  end
 
   # Mailgun URLs may look like `.../storage/abc?name=IMG.heic` (see `?#{att["name"]}`).
   def heic_like_url?(url)

--- a/spec/jobs/image_collage_job_spec.rb
+++ b/spec/jobs/image_collage_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe ImageCollageJob, type: :job do
+  include_context 'has all objects'
+
+  let(:message_id) { 'ABC-123@icloud.com' }
+
+  describe '#perform' do
+    before do
+      allow(Sentry).to receive(:capture_message)
+      allow(Sentry).to receive(:set_user)
+      allow(EntryMailer).to receive_message_chain(:image_error, :deliver_later)
+      allow(Rails.cache).to receive(:read).and_return(true)
+    end
+
+    it 'logs mailgun lookup diagnostics when no stored event is found' do
+      events_conn = instance_double(Faraday::Connection)
+      empty_resp = instance_double(Faraday::Response, success?: true, status: 200, body: { 'items' => [] })
+      allow(Faraday).to receive(:new).and_return(events_conn)
+      allow(events_conn).to receive(:get).and_return(empty_resp)
+      allow_any_instance_of(described_class).to receive(:sleep)
+
+      described_class.perform_now(paid_entry.id, message_id: message_id)
+
+      expect(Sentry).to have_received(:capture_message).with(
+        'Mailgun events lookup failed for collage attachments',
+        hash_including(
+          level: :warning,
+          extra: hash_including(
+            message_id: message_id,
+            lookup_attempts: be_present
+          )
+        )
+      )
+      expect(paid_entry.reload.image_error).to eq('No last message found')
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigates and mitigates `No last message found` errors from `ImageCollageJob` when building collages from multi-attachment inbound emails.

## Findings

- **Not a Mailgun API breaking change.** The Events API is deprecated in favor of Logs, but the underlying issue is how we query it.
- **Likely cause of increased frequency:** The April 19 change (`e4224ca6`) correctly routed multi-attachment emails on entries that already have an image through the Mailgun lookup path (previously they blew up with `URI::InvalidURIError`). That surfaced this failure mode more often.
- **Lookup bug:** We only queried `event=accepted`, but inbound multi-attachment emails are indexed as **`stored`** events. `accepted` is primarily outbound.
- **Sentry evidence ([DABBLE-ME-E](https://dabble-me.sentry.io/issues/DABBLE-ME-E)):** 8 occurrences since April; latest failure used message ID `45411CAB-01FE-4440-89FC-AC1EB465186A@icloud.com` and still failed after ~3 minutes of retries.

## Changes

- Try `stored` before `accepted`, then an unfiltered lookup
- Try message-id with and without angle brackets
- On failure, emit a dedicated Sentry warning with per-attempt diagnostics (HTTP status, item count, event filter, message-id variant)
- Include lookup context on the existing `Error updating collage image` Sentry event

## Test plan

- [x] `bundle exec rspec spec/jobs/image_collage_job_spec.rb`
- [ ] Monitor Sentry for `Mailgun events lookup failed for collage attachments` — should show which query variants return zero items

Fixes DABBLE-ME-E

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea57c5b5-d65f-4757-a5b4-8c2d33cde857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea57c5b5-d65f-4757-a5b4-8c2d33cde857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

