### PR TITLE
Improve Cursor cloud agent setup script

### DIFF
--- a/.cursor/agent/setup.sh
+++ b/.cursor/agent/setup.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+POSTGRESQL_VERSION="${POSTGRESQL_VERSION:-18}"
 
 log() {
   printf '\n== %s ==\n' "$1"
@@ -124,22 +125,41 @@ install_aptfile_packages() {
   done < "${APP_ROOT}/Aptfile"
 }
 
+install_postgresql() {
+  if ! command -v apt-get >/dev/null; then
+    return 0
+  fi
+
+  log "Installing PostgreSQL ${POSTGRESQL_VERSION} (PGDG)"
+  export DEBIAN_FRONTEND=noninteractive
+  run_as_root apt-get update -y
+  run_as_root apt-get install -y curl ca-certificates postgresql-common
+
+  if [ ! -f /etc/apt/sources.list.d/pgdg.sources ] && [ ! -f /etc/apt/sources.list.d/pgdg.list ]; then
+    run_as_root /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+  fi
+
+  run_as_root apt-get update -y
+  run_as_root apt-get install -y \
+    "postgresql-${POSTGRESQL_VERSION}" \
+    "postgresql-client-${POSTGRESQL_VERSION}" \
+    "postgresql-contrib-${POSTGRESQL_VERSION}"
+
+  if command -v pg_ctlcluster >/dev/null; then
+    run_as_root pg_ctlcluster "${POSTGRESQL_VERSION}" main start || true
+  fi
+}
+
 install_database_and_cache_services() {
   if ! command -v apt-get >/dev/null; then
     return 0
   fi
 
-  log 'Installing PostgreSQL and Redis'
+  log 'Installing Redis'
   run_as_root apt-get update -y
-  run_as_root apt-get install -y postgresql postgresql-contrib redis-server
+  run_as_root apt-get install -y redis-server
 
-  if command -v pg_ctlcluster >/dev/null; then
-    local cluster
-    cluster="$(pg_lsclusters -h | awk 'NR==1 {print $1}')"
-    if [ -n "$cluster" ]; then
-      run_as_root pg_ctlcluster "$cluster" main start || true
-    fi
-  fi
+  install_postgresql
 
   if command -v redis-server >/dev/null; then
     redis-server --daemonize yes 2>/dev/null || run_as_root systemctl start redis-server 2>/dev/null || true

--- a/.cursor/agent/setup.sh
+++ b/.cursor/agent/setup.sh
@@ -15,6 +15,80 @@ run_as_root() {
   fi
 }
 
+ensure_asdf() {
+  if [ -f "${HOME}/.asdf/asdf.sh" ]; then
+    return 0
+  fi
+
+  log 'Installing asdf'
+  git clone --depth 1 --branch v0.15.0 https://github.com/asdf-vm/asdf.git "${HOME}/.asdf"
+}
+
+load_asdf() {
+  # shellcheck disable=SC1091
+  . "${HOME}/.asdf/asdf.sh"
+}
+
+ensure_asdf_in_shell() {
+  local marker='# cursor-agent: asdf'
+  if ! grep -qF "$marker" "${HOME}/.bashrc" 2>/dev/null; then
+    cat >> "${HOME}/.bashrc" <<EOF
+$marker
+. "\$HOME/.asdf/asdf.sh"
+EOF
+  fi
+}
+
+install_asdf_plugins() {
+  load_asdf
+
+  if ! asdf plugin list | grep -qx ruby; then
+    asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
+  fi
+
+  if ! asdf plugin list | grep -qx nodejs; then
+    asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+    if [ -f "${HOME}/.asdf/plugins/nodejs/bin/import-release-team-keyring" ]; then
+      "${HOME}/.asdf/plugins/nodejs/bin/import-release-team-keyring"
+    fi
+  fi
+}
+
+install_asdf_runtimes() {
+  load_asdf
+  install_asdf_plugins
+
+  log 'Installing Ruby and Node.js from .tool-versions'
+  cd "$APP_ROOT"
+  asdf install
+}
+
+install_ruby_build_dependencies() {
+  if ! command -v apt-get >/dev/null; then
+    return 0
+  fi
+
+  log 'Installing Ruby build dependencies'
+  run_as_root apt-get update -y
+  run_as_root apt-get install -y \
+    autoconf \
+    bison \
+    build-essential \
+    curl \
+    git \
+    libffi-dev \
+    libgdbm-dev \
+    libgdbm6 \
+    libicu-dev \
+    libncurses5-dev \
+    libpq-dev \
+    libreadline-dev \
+    libssl-dev \
+    libyaml-dev \
+    pkg-config \
+    zlib1g-dev
+}
+
 install_aptfile_packages() {
   if ! command -v apt-get >/dev/null; then
     return 0
@@ -35,29 +109,50 @@ install_aptfile_packages() {
     fi
 
     if [[ "$line" =~ ^https?:// ]]; then
-      install_deb_from_url "$line"
-    else
-      run_as_root apt-get install -y "$line"
+      # Debian .deb URLs in Aptfile conflict on Ubuntu 24.04; use distro packages instead.
+      log "Skipping Aptfile URL on Ubuntu: $line"
+      run_as_root apt-get install -y libheif1 || true
+      continue
     fi
+
+    if [ "$line" = 'libvips' ]; then
+      run_as_root apt-get install -y libvips42t64 libvips-dev
+      continue
+    fi
+
+    run_as_root apt-get install -y "$line"
   done < "${APP_ROOT}/Aptfile"
 }
 
-install_deb_from_url() {
-  local url="$1"
+install_database_and_cache_services() {
+  if ! command -v apt-get >/dev/null; then
+    return 0
+  fi
 
-  (
-    local deb_path
-    deb_path="$(mktemp /tmp/aptfile.XXXXXX.deb)"
-    trap 'rm -f "$deb_path"' EXIT
-    curl -fsSL "$url" -o "$deb_path"
-    run_as_root dpkg -i "$deb_path" || run_as_root apt-get -f install -y
-  )
+  log 'Installing PostgreSQL and Redis'
+  run_as_root apt-get update -y
+  run_as_root apt-get install -y postgresql postgresql-contrib redis-server
+
+  if command -v pg_ctlcluster >/dev/null; then
+    local cluster
+    cluster="$(pg_lsclusters -h | awk 'NR==1 {print $1}')"
+    if [ -n "$cluster" ]; then
+      run_as_root pg_ctlcluster "$cluster" main start || true
+    fi
+  fi
+
+  if command -v redis-server >/dev/null; then
+    redis-server --daemonize yes 2>/dev/null || run_as_root systemctl start redis-server 2>/dev/null || true
+  fi
 }
 
 install_ruby_dependencies() {
-  log 'Installing Ruby dependencies'
+  load_asdf
+  cd "$APP_ROOT"
+
+  log 'Installing Ruby gems'
   gem install bundler --conservative
-  bundle check || bundle install
+  bundle check || bundle install --jobs 4 --retry 3
 }
 
 install_js_dependencies() {
@@ -65,15 +160,19 @@ install_js_dependencies() {
     return 0
   fi
 
-  if ! command -v npm >/dev/null; then
-    return 0
-  fi
+  load_asdf
+  cd "$APP_ROOT"
 
   log 'Installing JavaScript dependencies'
   if [ -f "${APP_ROOT}/package-lock.json" ]; then
     npm ci --no-audit --no-fund
   else
     npm install --no-audit --no-fund
+  fi
+
+  if grep -q '"build:css"' "${APP_ROOT}/package.json"; then
+    log 'Building marketing CSS'
+    npm run build:css
   fi
 }
 
@@ -83,13 +182,21 @@ prepare_database_if_requested() {
     return 0
   fi
 
+  load_asdf
+  cd "$APP_ROOT"
+
   log 'Preparing database'
   bin/rails db:prepare
 }
 
 main() {
   cd "$APP_ROOT"
+  install_ruby_build_dependencies
   install_aptfile_packages
+  install_database_and_cache_services
+  ensure_asdf
+  ensure_asdf_in_shell
+  install_asdf_runtimes
   install_ruby_dependencies
   install_js_dependencies
   prepare_database_if_requested

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Or ensure `~/.bashrc` sources it.
 ### Starting services
 
 ```bash
-sudo pg_ctlcluster 16 main start
+sudo pg_ctlcluster 18 main start
 redis-server --daemonize yes
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `.cursor/agent/setup.sh` so Cursor Cloud agents bootstrap the full Dabble Me dev environment on a fresh or saved machine.

## What changed

- Installs **asdf** and adds Ruby/Node plugins when missing
- Installs Ruby build deps, Aptfile packages (with Ubuntu 24.04 `libheif`/`libvips42t64` handling), **PostgreSQL 18 (PGDG)**, and Redis
- Runs `asdf install` from `.tool-versions`, `bundle install`, `npm ci`, and `npm run build:css`
- Appends asdf sourcing to `~/.bashrc` for future shells
- Keeps optional `CURSOR_RUN_DB_SETUP=1` for `bin/rails db:prepare`

## Cloud agent Update Script

Point the Cursor Cloud **Update Script** at this file (or use the lightweight version below):

```bash
set -euo pipefail
bash .cursor/agent/setup.sh
```

**Lightweight** (recommended on a saved snapshot):

```bash
set -euo pipefail
sudo pg_ctlcluster 18 main start 2>/dev/null || true
redis-server --daemonize yes 2>/dev/null || true
. "$HOME/.asdf/asdf.sh"
bundle check || bundle install --jobs 4 --retry 3
```

## Verified on this machine

- Ruby 3.4.8, Node 22.10.0
- `bundle check` passes (238 gems)
- PostgreSQL **18.4** online on port 5432, Redis PONG
- `public/marketing.css` built

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0833ebb-848d-480a-996d-83e7c1b4e2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0833ebb-848d-480a-996d-83e7c1b4e2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

