### PR TITLE
Fix photos disappearing when editing an entry

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -215,12 +215,11 @@ class EntriesController < ApplicationController
       flash[:notice] = 'Entry deleted!'
       redirect_back_or_to entries_path
     else
-      update_params = if @entry.image_url_cdn.present? && entry_params[:remove_image] == "0"
-        @entry.remote_image_url = @entry.image_url_cdn(cloudflare: false)
-        entry_params.permit(:entry, :date)
-      else
-        entry_params.permit(:entry, :date, :remove_image)
-      end
+      # Do not re-download / re-assign the existing image on every edit. That
+      # old remote_image_url workaround wiped photos when the CDN fetch failed
+      # (CarrierWave validate_download is false). Date changes relocate the
+      # stored object via Entry#relocate_image_on_date_change instead.
+      update_params = entry_params.permit(:entry, :date, :remove_image)
       if @entry.update(update_params)
         if params[:entry][:image].present? && params[:entry][:image].size > 1
           @entry.update(uploading_image: true)

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -40,6 +40,7 @@ class Entry < ActiveRecord::Base
   before_save :associate_inspiration
   before_save :strip_out_base64
   before_save :find_songs
+  before_update :relocate_image_on_date_change
 
   after_commit :tag_for_sentiment, if: :saved_change_to_body?, on: [:create, :update]
 
@@ -234,6 +235,22 @@ class Entry < ActiveRecord::Base
   end
 
   private
+
+  # ImageUploader#store_dir includes the entry date. Changing the date without
+  # moving the stored object makes image URLs 404. Relocate on S3 when keeping
+  # the photo; skip when the user checked "Remove Photo".
+  def relocate_image_on_date_change
+    return if read_attribute(:image).blank?
+    return unless will_save_change_to_date?
+    return if remove_image?
+
+    old_date = attribute_in_database('date')
+    new_date = date
+    return if old_date.blank? || new_date.blank?
+    return if old_date.to_date == new_date.to_date
+
+    image.relocate_between_dates!(old_date, new_date)
+  end
 
   def associate_inspiration
     self.inspiration = nil unless self.inspiration.in? Inspiration.without_imports_or_email_or_tips

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -56,16 +56,81 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def heic_image?(new_file)
-    # Detect HEIC/HEIF by MIME type or file extension on the original filename
-    content_type = new_file&.content_type.to_s
-    original_name = new_file.respond_to?(:filename) ? new_file.filename.to_s : ""
+    # Detect HEIC/HEIF by MIME type or file extension on the original filename.
+    # Avoid ActiveSupport blank? on Fog files — that calls exists? and HEADs S3.
+    return false if new_file.nil?
+
+    content_type = begin
+      new_file.respond_to?(:content_type) ? new_file.content_type.to_s : ''
+    rescue StandardError
+      ''
+    end
+    original_name = begin
+      if new_file.respond_to?(:filename)
+        new_file.filename.to_s
+      elsif new_file.respond_to?(:path)
+        File.basename(new_file.path.to_s)
+      else
+        ''
+      end
+    rescue StandardError
+      ''
+    end
     ext = File.extname(original_name).downcase
-    # Match image/heic, image/heif MIME types or .heic/.heif extensions
     content_type.in?(%w[image/heic image/heif]) || ext.in?(%w[.heic .heif])
   end
 
   def store_dir
+    store_dir_for(model.date)
+  end
+
+  # CarrierWave store paths include the entry date. When that date changes,
+  # URLs point at a new key while the object remains under the old key unless
+  # we move it. Call this before the new date is persisted.
+  def relocate_between_dates!(from_date, to_date)
+    return if from_date.blank? || to_date.blank?
+    return if from_date.to_date == to_date.to_date
+
+    filename = model.read_attribute(mounted_as).presence
+    return if filename.blank?
+
+    old_dir = store_dir_for(from_date)
+    new_dir = store_dir_for(to_date)
+
+    filenames_to_move(filename).each do |name|
+      move_stored_key!("#{old_dir}/#{name}", "#{new_dir}/#{name}")
+    end
+  end
+
+  def store_dir_for(date)
     add_dev = "/development" unless Rails.env.production?
-    "uploads#{add_dev}/#{model.user.user_key}/#{model.date.strftime("%Y-%m-%d")}"
+    "uploads#{add_dev}/#{model.user.user_key}/#{date.strftime('%Y-%m-%d')}"
+  end
+
+  private
+
+  def filenames_to_move(filename)
+    names = [filename]
+    # CarrierWave stores versions as "#{version_name}_#{parent_filename}" in the
+    # same directory (e.g. jpeg_photo.heic for HEIC conversions).
+    versions.each_key do |version_name|
+      names << "#{version_name}_#{filename}"
+    end
+    names.uniq
+  end
+
+  def move_stored_key!(old_key, new_key)
+    return if old_key == new_key
+
+    storage = CarrierWave::Storage::Fog.new(self)
+    old_file = CarrierWave::Storage::Fog::File.new(self, storage, old_key)
+    return unless old_file.exists?
+
+    old_file.copy_to(new_key)
+    old_file.delete
+  rescue => e
+    Rails.logger.error("Failed to relocate image from #{old_key} to #{new_key}: #{e.message}")
+    Sentry.capture_exception(e, extra: { type: "Image relocate failed", old_key: old_key, new_key: new_key, entry_id: model.id })
+    raise
   end
 end

--- a/spec/controllers/entries_controller_update_image_spec.rb
+++ b/spec/controllers/entries_controller_update_image_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe EntriesController, '#update image persistence', type: :controller do
+  include_context 'has all objects'
+
+  let(:original_date) { Date.new(2026, 7, 18) }
+  let(:new_date) { Date.new(2026, 7, 17) }
+  let(:image_filename) { 'journal-photo.jpg' }
+
+  before do
+    paid_user
+    paid_entry.update_columns(date: original_date, image: image_filename, body: 'Original body with a photo')
+    sign_in paid_user
+  end
+
+  def update_entry(attrs)
+    # Stub fog interactions that CarrierWave triggers when remove_image is present.
+    allow_any_instance_of(ImageUploader).to receive(:relocate_between_dates!).and_return(nil)
+    allow_any_instance_of(ImageUploader).to receive(:remove!).and_return(true)
+    allow_any_instance_of(ImageUploader).to receive(:blank?).and_return(false)
+    fog_file = instance_double(
+      CarrierWave::Storage::Fog::File,
+      content_type: 'image/jpeg',
+      filename: image_filename,
+      path: "uploads/development/key/#{image_filename}",
+      empty?: false,
+      exists?: true,
+      delete: true,
+      size: 10
+    )
+    allow_any_instance_of(ImageUploader).to receive(:file).and_return(fog_file)
+
+    put :update, params: {
+      id: paid_entry.id,
+      entry: {
+        entry: attrs.fetch(:entry, paid_entry.body),
+        date: attrs.fetch(:date, paid_entry.date).strftime('%B %-d, %Y'),
+        remove_image: attrs.fetch(:remove_image, '0')
+      }
+    }
+  end
+
+  it 'keeps the photo when changing the date without toggling remove-photo' do
+    expect_any_instance_of(ImageUploader).to receive(:relocate_between_dates!).with(original_date, new_date).and_return(nil)
+
+    update_entry(date: new_date, entry: 'Updated after midnight', remove_image: '0')
+
+    expect(response).to redirect_to(day_entry_path(year: new_date.year, month: new_date.month, day: new_date.day))
+    paid_entry.reload
+    expect(paid_entry.date).to eq(new_date)
+    expect(paid_entry.read_attribute(:image)).to eq(image_filename)
+  end
+
+  it 'does not re-download the image via remote_image_url on a normal edit' do
+    expect_any_instance_of(Entry).not_to receive(:remote_image_url=)
+
+    update_entry(date: original_date, entry: 'Just editing the text', remove_image: '0')
+
+    expect(response).to redirect_to(day_entry_path(year: original_date.year, month: original_date.month, day: original_date.day))
+    paid_entry.reload
+    expect(paid_entry.read_attribute(:image)).to eq(image_filename)
+  end
+
+  it 'clears the photo when remove_image is checked' do
+    update_entry(date: original_date, entry: paid_entry.body, remove_image: '1')
+
+    expect(response).to redirect_to(day_entry_path(year: original_date.year, month: original_date.month, day: original_date.day))
+    paid_entry.reload
+    expect(paid_entry.read_attribute(:image)).to be_blank
+  end
+end

--- a/spec/controllers/import_controller_spec.rb
+++ b/spec/controllers/import_controller_spec.rb
@@ -4,17 +4,12 @@ require "rails_helper"
 
 RSpec.describe ImportController, type: :controller do
   include_context "has all objects"
+  # ActiveJob::TestHelper enables/disables a per-example test adapter via
+  # before_setup/after_teardown. Do not also assign ActiveJob::Base.queue_adapter
+  # around examples — capturing queue_adapter while the test adapter is active
+  # and writing it back leaks TestAdapter into later examples, so deliver_later
+  # stops delivering into ActionMailer::Base.deliveries.
   include ActiveJob::TestHelper
-
-  around do |example|
-    previous_adapter = ActiveJob::Base.queue_adapter
-    ActiveJob::Base.queue_adapter = :test
-    clear_enqueued_jobs
-    example.run
-  ensure
-    clear_enqueued_jobs
-    ActiveJob::Base.queue_adapter = previous_adapter
-  end
 
   after { FileUtils.rm_rf(ImportUploadStore::BASE_DIR) }
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -189,10 +189,13 @@ RSpec.describe RegistrationsController, type: :controller do
 
   describe "destroy" do
     around do |example|
-      previous_adapter = ActiveJob::Base.queue_adapter
       ActiveJob::Base.queue_adapter = :test
       example.run
-      ActiveJob::Base.queue_adapter = previous_adapter
+    ensure
+      # Always restore the test-env default. Capturing queue_adapter while a
+      # TestAdapter is active (e.g. from ActiveJob::TestHelper) and writing it
+      # back leaks enqueue-only delivery into later examples.
+      ActiveJob::Base.queue_adapter = :inline
     end
 
     it "redirects when not signed in" do

--- a/spec/jobs/image_collage_job_spec.rb
+++ b/spec/jobs/image_collage_job_spec.rb
@@ -8,16 +8,12 @@ RSpec.describe ImageCollageJob, type: :job do
 
   describe '.perform_later_for_mailgun' do
     it 'waits for Mailgun to index the stored event before running' do
-      previous_adapter = ActiveJob::Base.queue_adapter
-      ActiveJob::Base.queue_adapter = :test
-
+      # ActiveJob::TestHelper already installs a test adapter for this example.
       expect do
         described_class.perform_later_for_mailgun(paid_entry.id, message_id: message_id)
       end.to have_enqueued_job(described_class)
         .with(paid_entry.id, message_id: message_id)
         .at(a_value_within(1.second).of(described_class::MAILGUN_INDEX_DELAY.from_now))
-
-      ActiveJob::Base.queue_adapter = previous_adapter
     end
   end
 

--- a/spec/models/entry_image_relocation_spec.rb
+++ b/spec/models/entry_image_relocation_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Entry, 'image relocation on date change' do
+  include_context 'has all objects'
+
+  let(:original_date) { Date.new(2026, 7, 18) }
+  let(:new_date) { Date.new(2026, 7, 17) }
+  let(:image_filename) { 'journal-photo.jpg' }
+  let(:uploader) { instance_double(ImageUploader) }
+
+  before do
+    paid_entry.update_columns(date: original_date, image: image_filename, body: 'Original body with a photo')
+    paid_entry.reload
+    allow(paid_entry).to receive(:image).and_return(uploader)
+  end
+
+  describe '#relocate_image_on_date_change' do
+    it 'relocates when the date is changing and a photo is kept' do
+      paid_entry.date = new_date
+      expect(uploader).to receive(:relocate_between_dates!).with(original_date, new_date)
+
+      paid_entry.send(:relocate_image_on_date_change)
+    end
+
+    it 'does nothing when the date is unchanged' do
+      paid_entry.body = 'Just editing the text'
+      expect(uploader).not_to receive(:relocate_between_dates!)
+
+      paid_entry.send(:relocate_image_on_date_change)
+    end
+
+    it 'does nothing when remove_image? is true' do
+      paid_entry.date = new_date
+      allow(paid_entry).to receive(:remove_image?).and_return(true)
+      expect(uploader).not_to receive(:relocate_between_dates!)
+
+      paid_entry.send(:relocate_image_on_date_change)
+    end
+
+    it 'does nothing when there is no photo' do
+      paid_entry.update_columns(image: nil)
+      paid_entry.reload
+      allow(paid_entry).to receive(:image).and_return(uploader)
+      paid_entry.date = new_date
+      expect(uploader).not_to receive(:relocate_between_dates!)
+
+      paid_entry.send(:relocate_image_on_date_change)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -138,11 +138,10 @@ describe User do
 
   describe '#send_devise_notification' do
     around do |example|
-      previous_adapter = ActiveJob::Base.queue_adapter
       ActiveJob::Base.queue_adapter = :test
       example.run
     ensure
-      ActiveJob::Base.queue_adapter = previous_adapter
+      ActiveJob::Base.queue_adapter = :inline
     end
 
     it 'enqueues reset password instructions instead of delivering them synchronously' do

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe ImageUploader, '#relocate_between_dates!' do
+  include_context 'has all objects'
+
+  let(:from_date) { Date.new(2026, 7, 18) }
+  let(:to_date) { Date.new(2026, 7, 17) }
+  let(:filename) { 'journal-photo.jpg' }
+  let(:entry) do
+    paid_entry.tap do |e|
+      e.update_columns(date: to_date, image: filename)
+    end
+  end
+  let(:uploader) { entry.image }
+
+  def fog_file_double(exists:)
+    instance_double(CarrierWave::Storage::Fog::File, exists?: exists).tap do |file|
+      allow(file).to receive(:copy_to)
+      allow(file).to receive(:delete)
+    end
+  end
+
+  it 'copies the original and version keys from the old date path to the new one' do
+    storage = instance_double(CarrierWave::Storage::Fog)
+    allow(CarrierWave::Storage::Fog).to receive(:new).and_return(storage)
+
+    old_original = fog_file_double(exists: true)
+    old_jpeg = fog_file_double(exists: true)
+    missing = fog_file_double(exists: false)
+
+    allow(CarrierWave::Storage::Fog::File).to receive(:new) do |_uploader, _storage, key|
+      case key
+      when %r{/2026-07-18/journal-photo\.jpg\z} then old_original
+      when %r{/2026-07-18/jpeg_journal-photo\.jpg\z} then old_jpeg
+      else missing
+      end
+    end
+
+    uploader.relocate_between_dates!(from_date, to_date)
+
+    expect(old_original).to have_received(:copy_to).with(%r{/2026-07-17/journal-photo\.jpg\z})
+    expect(old_original).to have_received(:delete)
+    expect(old_jpeg).to have_received(:copy_to).with(%r{/2026-07-17/jpeg_journal-photo\.jpg\z})
+    expect(old_jpeg).to have_received(:delete)
+  end
+
+  it 'does nothing when the dates are the same' do
+    expect(CarrierWave::Storage::Fog::File).not_to receive(:new)
+    uploader.relocate_between_dates!(from_date, from_date)
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Updating an entry (especially changing the date after writing past midnight) could make existing photos disappear. Users found that toggling **Remove Photo** on and off before saving would keep the photos — a workaround that pointed at buggy update handling.

## Root cause

1. `ImageUploader#store_dir` includes the entry **date**, so after a date change CarrierWave builds URLs under the new date path while the file remains under the old S3 key.
2. The update action tried to paper over this by re-downloading via `remote_image_url` whenever `remove_image == "0"`. With `validate_download = false`, a failed CDN fetch could clear the image on ordinary edits.

## Fix

- On date change (when keeping the photo), **relocate** the stored object from the old date path to the new one (including CarrierWave version keys).
- Stop re-assigning/re-downloading the existing image on every update.
- Leave **Remove Photo** behavior unchanged.

## CI fix (same PR)

Payments/registrations mailer specs were failing because `import_controller_spec` leaked ActiveJob's `TestAdapter` into later examples (capturing `queue_adapter` while `ActiveJob::TestHelper` was active and writing it back). `deliver_later` then only enqueued, so `ActionMailer::Base.deliveries` stayed empty. Specs that swap adapters now restore `:inline` cleanly.

## Tests

- Model callback coverage for relocate / skip conditions
- Controller coverage: date change keeps photo, body-only edit does not call `remote_image_url=`, remove checkbox clears photo
- Uploader unit coverage for S3 key copy/delete between date paths
- Confirmed import → payments/registrations mailer specs pass together
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7bf7-7eb4-707f-b0e7-2da4c50aa748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7bf7-7eb4-707f-b0e7-2da4c50aa748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

