### PR TITLE
docs: note ubuntu Postgres role requirement for cloud dev setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ sudo pg_ctlcluster 18 main start
 redis-server --daemonize yes
 ```
 
+`config/database.yml` sets no DB username, so the app connects to Postgres via peer auth as the OS user `ubuntu`. If a fresh cluster errors with `role "ubuntu" does not exist`, create it once:
+
+```bash
+sudo -u postgres psql -c "CREATE ROLE ubuntu WITH LOGIN SUPERUSER;"
+```
+
+Then create/seed the dev DB with the dev env vars: `bundle exec rails db:create db:schema:load db:seed`.
+
 ### Running the dev server
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Dabble Me development environment in Cursor Cloud, and adds one non-obvious startup gotcha to `AGENTS.md`.

`config/database.yml` specifies no DB username, so the app connects to Postgres via peer auth as OS user `ubuntu`. On a fresh cluster this errors with `role "ubuntu" does not exist`, blocking `db:create`/`db:seed`. Documented the one-time `CREATE ROLE` fix under **Starting services**.

## Environment verification

- Dependencies: gems (`bundle check` satisfied), `node_modules` present, `npm run build:css` → `public/marketing.css`.
- Services: PostgreSQL 18 cluster + Redis started.
- Databases: `db:create db:schema:load db:seed` created dev/test DBs and seed users.
- Tests: `bundle exec rspec` → **199 examples, 0 failures, 1 pending**.
- Dev server: Puma on `:3000`, homepage `200`.
- Hello-world: logged in as `admin@dabble.ex` and created a journal entry (success confirmation shown).

<a href="https://cursor.com/agents/bc-c7bbfd38-0ec0-4cea-8b6a-b0e7c21c110c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdabble_me_login_and_create_entry.mp4"><img src="https://cursor.com/artifacts/c/art-f0230269-5fe6-4f3d-93a1-576b6f674a99" alt="dabble_me_login_and_create_entry.mp4" /></a>
![Entry created successfully](https://cursor.com/artifacts/c/art-8dcc60b9-072b-452c-8f0c-ed5d0f3ecce7)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7bbfd38-0ec0-4cea-8b6a-b0e7c21c110c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7bbfd38-0ec0-4cea-8b6a-b0e7c21c110c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

