### PR TITLE
Fix unauthorized day-entry views and speed up entries index/show

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -46,7 +46,7 @@ class EntriesController < ApplicationController
       @title = 'All Entries'
     end
 
-    @entries = @entries.page(params[:page]).per(params[:per])
+    @entries = @entries.page(params[:page]).per(index_per_page)
 
     if @entries.empty? && params[:format] != "json"
       flash[:alert] = "No entries found." if params[:emotion].present? || params[:group].present? || params[:subgroup].present?
@@ -86,8 +86,9 @@ class EntriesController < ApplicationController
 
   def set_years_ago
     user_time = Time.now.in_time_zone(current_user.send_timezone)
-    years_back_dates = (1..5).map { |y| (user_time - y.years).strftime("%Y-%m-%d") }
-    @years_ago_entries = current_user.entries.where(date: years_back_dates).index_by { |e| (user_time.year - e.date.year) }
+    day_ranges = (1..5).map { |y| (user_time - y.years).to_date.all_day }
+    years_ago_scope = day_ranges.map { |range| current_user.entries.where(date: range) }.reduce(:or)
+    @years_ago_entries = (years_ago_scope || current_user.entries.none).index_by { |e| (user_time.year - e.date.year) }
   end
 
   def random
@@ -409,20 +410,29 @@ class EntriesController < ApplicationController
 
   def set_entry
     if params[:day].present?
-      date = Date.parse("#{params[:year]}-#{params[:month]}-#{params[:day]}")
-      @entry = current_user.entries.includes(:inspiration).where(date: date).first
+      date = Date.new(params[:year].to_i, params[:month].to_i, params[:day].to_i)
+      # entries.date is datetime; match the whole calendar day (see User#existing_entry)
+      @entry = current_user.entries.includes(:inspiration).where(date: date.all_day).first
     else
       @entry = current_user.entries.includes(:inspiration).where(id: params[:id]).first
     end
-  rescue
-    flash[:alert] = "Entry not found."
+  rescue ArgumentError, TypeError
+    @entry = nil
+    flash[:alert] = 'Entry not found.'
   end
 
   def require_entry_permission
-    return false if @entry.present? && current_user == @entry.user
+    return if @entry.present? && current_user == @entry.user
 
-    flash[:alert] = 'Not authorized'
+    flash[:alert] = @entry.blank? ? 'Entry not found.' : 'Not authorized'
     redirect_to entries_path
+  end
+
+  def index_per_page
+    per = params[:per].presence&.to_i
+    return Kaminari.config.default_per_page if per.blank? || per <= 0
+
+    per.clamp(1, 50)
   end
 
   def random_inspiration

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -89,14 +89,7 @@ class Entry < ActiveRecord::Base
   def formatted_body
     return nil unless body.present?
     @formatted_body ||= begin
-      formatted = body
-      begin
-        detection = CharlockHolmes::EncodingDetector.detect(body)
-        if detection[:confidence] > 95
-          formatted = CharlockHolmes::Converter.convert formatted, detection[:encoding].gsub("IBM424_ltr", "UTF-8"), "UTF-8"
-        end
-      rescue => e
-      end
+      formatted = ensure_utf8(body)
       fix_encoding(formatted)
     end
   end
@@ -123,15 +116,9 @@ class Entry < ActiveRecord::Base
     body_sanitized = safe_list_sanitizer.sanitize(self.body, tags: %w(br p))
     body_sanitized.gsub!(/\A(\n\n)/,"") if body_sanitized
     body_sanitized.gsub!(/(\<\n\n>)\z/,"") if body_sanitized
+    return nil if body_sanitized.blank?
 
-    begin
-      detection = CharlockHolmes::EncodingDetector.detect(body_sanitized)
-      if detection[:confidence] > 95
-        body_sanitized = CharlockHolmes::Converter.convert body_sanitized, detection[:encoding].gsub("IBM424_ltr", "UTF-8"), "UTF-8"
-      end
-    rescue => e
-    end
-    fix_encoding(body_sanitized)
+    fix_encoding(ensure_utf8(body_sanitized))
   end
 
   def image_url_cdn(cloudflare: true)
@@ -180,11 +167,11 @@ class Entry < ActiveRecord::Base
   end
 
   def next
-    self.user.entries.where("date > ?", date).sort_by(&:date).first
+    @next_entry ||= user.entries.unscope(:order).where('date > ?', date).order(date: :asc).first
   end
 
   def previous
-    self.user.entries.where("date < ?", date).sort_by(&:date).last
+    @previous_entry ||= user.entries.unscope(:order).where('date < ?', date).order(date: :desc).first
   end
 
   def hashtags
@@ -295,11 +282,26 @@ class Entry < ActiveRecord::Base
     nil
   end
 
+  # Skip CharlockHolmes when the string is already valid UTF-8 — the common
+  # case for journal bodies, and much cheaper on the entries index.
+  def ensure_utf8(string)
+    return string if string.encoding == Encoding::UTF_8 && string.valid_encoding?
+
+    detection = CharlockHolmes::EncodingDetector.detect(string)
+    if detection && detection[:confidence].to_i > 95 && detection[:encoding].present?
+      CharlockHolmes::Converter.convert(string, detection[:encoding].gsub('IBM424_ltr', 'UTF-8'), 'UTF-8')
+    else
+      string
+    end
+  rescue StandardError
+    string
+  end
+
   def fix_encoding(string)
     return string unless string&.scan(/\\u[0-9a-zA-Z]{4}/)&.any?
 
     begin
-      string&.encode("ISO-8859-1")&.force_encoding("UTF-8")
+      string&.encode('ISO-8859-1')&.force_encoding('UTF-8')
     rescue Encoding::UndefinedConversionError
       string
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,10 +95,12 @@ class User < ActiveRecord::Base
     end
   end
 
+  # Entries.date is a datetime. Match any timestamp on the given calendar day
+  # (UTC, matching config.time_zone) so non-midnight values still resolve.
   def existing_entry(selected_date)
-    selected_date = Date.parse(selected_date.to_s)
-    entries.where(date: selected_date).first
-  rescue
+    date = Date.parse(selected_date.to_s)
+    entries.where(date: date.all_day).first
+  rescue ArgumentError, TypeError
     nil
   end
 

--- a/app/views/entries/_sidebar.html.haml
+++ b/app/views/entries/_sidebar.html.haml
@@ -1,5 +1,4 @@
 - dashboard = local_assigns[:dashboard] || false
-- current_user_entries = current_user.entries
 
 .col-md-8.col-md-offset-1
   = render "pro_upgrade"

--- a/app/views/entries/show.html.haml
+++ b/app/views/entries/show.html.haml
@@ -1,18 +1,21 @@
 - title "Entry on #{@entry.date_format_short}"
 
+- previous_entry = @entry.previous
+- next_entry = @entry.next
+
 .row
   .col-md-8.col-md-offset-2
     .center
       .pagination
-        - if @entry.previous.present?
-          =link_to "« Prev", day_entry_path(year: @entry.previous.date.year, month: @entry.previous.date.month, day: @entry.previous.date.day), id: "previous-entry", rel: "tooltip", title: "#{@entry.previous.date_format_short}"
+        - if previous_entry.present?
+          =link_to "« Prev", day_entry_path(year: previous_entry.date.year, month: previous_entry.date.month, day: previous_entry.date.day), id: "previous-entry", rel: "tooltip", title: "#{previous_entry.date_format_short}"
         - else
           %span{style: "color: #999; cursor: not-allowed;"} « Prev
 
         = link_to "Random", random_entry_path, style: "margin: 0 30px;"
 
-        - if @entry.next.present?
-          =link_to "Next »", day_entry_path(year: @entry.next.date.year, month: @entry.next.date.month, day: @entry.next.date.day), id: "next-entry", rel: "tooltip", title: "#{@entry.next.date_format_short}"
+        - if next_entry.present?
+          =link_to "Next »", day_entry_path(year: next_entry.date.year, month: next_entry.date.month, day: next_entry.date.day), id: "next-entry", rel: "tooltip", title: "#{next_entry.date_format_short}"
         - else
           %span{style: "color: #999; cursor: not-allowed;"} Next »
     .clearfix

--- a/spec/controllers/entries_controller_spec.rb
+++ b/spec/controllers/entries_controller_spec.rb
@@ -24,6 +24,48 @@ RSpec.describe EntriesController, type: :controller do
       expect(response.body).to have_content(entry.formatted_body)
       expect(response.body).not_to have_content(not_my_entry.formatted_body)
     end
+
+    it 'should clamp per page to a sane maximum' do
+      sign_in user
+      get :index, params: { per: 500 }
+      expect(response.status).to eq 200
+      expect(controller.send(:index_per_page)).to eq 50
+    end
+  end
+
+  describe 'show' do
+    before { sign_in user }
+
+    it 'shows an entry stored at a non-midnight datetime for that calendar day' do
+      entry.update_columns(date: Time.utc(2026, 7, 17, 15, 30, 0), body: '<p>UniqueShowBody999</p>')
+
+      get :show, params: { year: 2026, month: 7, day: 17 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('UniqueShowBody999')
+      expect(flash[:alert]).to be_blank
+    end
+
+    it 'shows a timezone beginning-of-day entry for that calendar day' do
+      tz = ActiveSupport::TimeZone[user.send_timezone]
+      day = Date.new(2026, 7, 17)
+      entry.update_columns(
+        date: tz.local(day.year, day.month, day.day).beginning_of_day,
+        body: '<p>McpStyleShowBody</p>'
+      )
+
+      get :show, params: { year: 2026, month: 7, day: 17 }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('McpStyleShowBody')
+    end
+
+    it 'redirects with Entry not found when no entry exists that day' do
+      get :show, params: { year: 2099, month: 1, day: 1 }
+
+      expect(response).to redirect_to(entries_path)
+      expect(flash[:alert]).to eq('Entry not found.')
+    end
   end
 
   describe 'edit' do
@@ -82,9 +124,27 @@ RSpec.describe EntriesController, type: :controller do
       sign_in user
       user.plan = 'PRO PayHere Monthly'
       user.save
+      params[:entry][:date] = Date.new(2027, 3, 15)
       expect { post :create, params: params }.to change { Entry.count }.by(1)
       expect(response.status).to eq 302
-      expect(response).to redirect_to(day_entry_url(year: Entry.last.date.year, month: Entry.last.date.month, day: Entry.last.date.day))
+      expect(response).to redirect_to(day_entry_url(year: 2027, month: 3, day: 15))
+    end
+
+    it 'should merge into an existing same-day entry if paid user' do
+      sign_in paid_user
+      existing = paid_user.entries.create!(date: Time.utc(2026, 8, 1, 15, 0, 0), body: '<p>Morning</p>')
+      merge_params = {
+        entry: {
+          entry: 'Afternoon addition',
+          date: Time.utc(2026, 8, 1, 9, 0, 0),
+          inspiration_id: inspiration.id
+        }
+      }
+
+      expect { post :create, params: merge_params }.not_to change { Entry.count }
+      expect(response).to redirect_to(day_entry_url(year: 2026, month: 8, day: 1))
+      expect(existing.reload.body).to include('Morning')
+      expect(existing.body).to include('Afternoon addition')
     end
   end
 

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -15,7 +15,10 @@ describe 'Day Entries' do
     it 'should show an entry to logged in users' do
       sign_in user
       visit day_entry_url(year: entry.date.year, month: entry.date.month, day: entry.date.day)
+      expect(page).to have_current_path(day_entry_path(year: entry.date.year, month: entry.date.month, day: entry.date.day))
       expect(page).to have_content entry.formatted_body
+      expect(page).not_to have_content 'Not authorized'
+      expect(page).not_to have_content 'Entry not found'
 
       visit random_entry_url
       expect(page).to have_content entry.formatted_body
@@ -25,10 +28,35 @@ describe 'Day Entries' do
       expect(page).to have_content 'You need to login or sign up before continuing.'
     end
 
-    it 'should not show me other users entries' do
+    it 'should show an entry stored at a non-midnight datetime' do
+      sign_in user
+      entry.update_columns(date: Time.utc(2026, 7, 17, 15, 30, 0), body: '<p>Afternoon journal entry</p>')
+
+      visit day_entry_url(year: 2026, month: 7, day: 17)
+      expect(page).to have_current_path(day_entry_path(year: 2026, month: 7, day: 17))
+      expect(page).to have_content 'Afternoon journal entry'
+      expect(page).not_to have_content 'Not authorized'
+    end
+
+    it 'should show a timezone-midnight entry (e.g. MCP-created)' do
+      sign_in user
+      tz = ActiveSupport::TimeZone[user.send_timezone]
+      day = Date.new(2026, 7, 17)
+      entry.update_columns(
+        date: tz.local(day.year, day.month, day.day).beginning_of_day,
+        body: '<p>Timezone day start entry</p>'
+      )
+
+      visit day_entry_url(year: 2026, month: 7, day: 17)
+      expect(page).to have_content 'Timezone day start entry'
+      expect(page).not_to have_content 'Not authorized'
+    end
+
+    it 'should say entry not found for a day without an entry' do
       sign_in user
       visit day_entry_url(year: entry.date.year + 1, month: entry.date.month, day: entry.date.day)
-      expect(page).to have_content 'Not authorized'
+      expect(page).to have_content 'Entry not found'
+      expect(page).not_to have_content 'Not authorized'
     end
 
     it 'should not show me other users entries' do
@@ -40,7 +68,7 @@ describe 'Day Entries' do
     it 'should not show me other users entries in edit mode' do
       sign_in user
       visit edit_entry_url(not_my_entry)
-      expect(page).to have_content 'Not authorized'
+      expect(page).to have_content 'Entry not found'
     end
 
     it 'should show me the calendar with my entries', js: true do

--- a/spec/models/entry_navigation_spec.rb
+++ b/spec/models/entry_navigation_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Entry do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe '#next and #previous' do
+    it 'returns neighboring entries with SQL order/limit instead of loading the whole collection' do
+      older = user.entries.create!(date: Time.utc(2026, 7, 10, 12, 0, 0), body: 'older')
+      middle = user.entries.create!(date: Time.utc(2026, 7, 17, 12, 0, 0), body: 'middle')
+      newer = user.entries.create!(date: Time.utc(2026, 7, 20, 12, 0, 0), body: 'newer')
+
+      expect(middle.previous).to eq(older)
+      expect(middle.next).to eq(newer)
+      expect(older.previous).to be_nil
+      expect(newer.next).to be_nil
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -152,4 +152,14 @@ describe User do
       end.to have_enqueued_mail(Devise::Mailer, :reset_password_instructions)
     end
   end
+
+  describe '#existing_entry' do
+    it 'finds an entry stored at a non-midnight datetime on that calendar day' do
+      entry = user.entries.create!(date: Time.utc(2099, 3, 15, 18, 45, 0), body: 'afternoon')
+
+      expect(user.existing_entry('2099-03-15')).to eq(entry)
+      expect(user.existing_entry(Date.new(2099, 3, 15))).to eq(entry)
+      expect(user.existing_entry('2099-03-16')).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Visiting `/entries/2026/7/17` (and other day links) could flash **Not authorized** even when the user had an entry that day.

`entries.date` is a **datetime**, but `EntriesController#set_entry` and `User#existing_entry` looked up with exact `Date` equality (midnight UTC). Entries stored with a time component—MCP timezone beginning-of-day, afternoon writes, factory/`DateTime.now` style timestamps—did not match, `@entry` was nil, and the permission filter treated that as unauthorized.

The feature specs were false positives: a failed show redirected to the index, which still rendered the entry body.

## Fix

- Look up by full calendar day (`date.all_day`) in `set_entry` and `existing_entry`
- Show **Entry not found** when missing; reserve **Not authorized** for real ownership failures
- Same-day merge via `existing_entry` now works for non-midnight timestamps

## Performance

- `Entry#next` / `#previous`: SQL `ORDER BY … LIMIT 1` + memoization (previously loaded all neighbors into Ruby and sorted); show view evaluates each once
- Skip CharlockHolmes when body is already valid UTF-8 (common case on the index)
- Cap `per` at 50 on the index
- Years-ago sidebar lookup uses day ranges instead of midnight equality

## Tests

Controller, feature, and model coverage for non-midnight / timezone-midnight show, missing-day messaging, same-day merge, and neighbor navigation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9155-0df5-7fb7-b54c-7f96d449230b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9155-0df5-7fb7-b54c-7f96d449230b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

