### PR TITLE
Strengthen MCP journal guide prompts and Claude/ChatGPT title

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -182,7 +182,7 @@ module ApplicationHelper
           },
           {
             q: "Is there a mobile app?",
-            a: "<span class='font-semibold'>No — and that’s intentional.</span> There’s no Dabble Me app in the App Store or Google Play. Most people write by replying to the daily email using the email app they already have on their phone. The website is fully mobile-friendly if you ever want to browse or edit entries."
+            a: "<span class='font-semibold'>No — and that’s intentional.</span> There’s no standalone Dabble Me app in the App Store or Google Play. Most people write by replying to the daily email using the email app already on their phone, and the website is fully mobile-friendly for browsing or editing entries. PRO members can also <a href='#{routes.mcp_server_docs_path}' class='text-accent hover:text-primary underline'>connect Dabble Me to ChatGPT, Claude, or another MCP-compatible AI app</a>. Once connected, you can use that app on the go—and use voice prompts where the AI app supports them—to find memories, reflect on past entries, or add a new journal entry."
           },
           {
             q: "Is this really free?",

--- a/app/views/shared/_marketing_footer.html.erb
+++ b/app/views/shared/_marketing_footer.html.erb
@@ -16,15 +16,15 @@
             <li>
               <a href="<%= root_path(s: (user_signed_in? ? '0' : nil), anchor: 'pricing') %>" class="text-sm text-muted hover:text-primary transition-colors">Pricing</a>
             </li>
+            <li>
+              <a href="<%= support_path %>" class="text-sm text-muted hover:text-primary transition-colors">Support</a>
+            </li>
           </ul>
         </div>
 
         <!-- Resources -->
         <div>
           <ul role="list" class="mt-4 space-y-3">
-            <li>
-              <a href="<%= support_path %>" class="text-sm text-muted hover:text-primary transition-colors">Support</a>
-            </li>
             <li>
               <a href="<%= mcp_server_docs_path %>" class="text-sm text-muted hover:text-primary transition-colors">MCP Server</a>
             </li>

--- a/app/views/welcome/best_journaling_apps_with_mcp.html.erb
+++ b/app/views/welcome/best_journaling_apps_with_mcp.html.erb
@@ -1,5 +1,5 @@
-<% content_for :title, "Best Journaling Apps with MCP / Claude & ChatGPT Connectors" %>
-<% content_for :social_title, "Best journaling apps with MCP / Claude & ChatGPT Connectors" %>
+<% content_for :title, "Best Journaling Apps with MCP / Claude and ChatGPT Connectors" %>
+<% content_for :social_title, "Best journaling apps with MCP / Claude and ChatGPT Connectors" %>
 <% content_for :description, "A practical guide to journaling apps with vendor-supported MCP integrations for Claude and ChatGPT, including Dabble Me and Day One, setup differences, security, and AI reflection prompts." %>
 <% content_for :keywords, "best journaling apps with MCP,Claude ChatGPT connectors,AI journal with MCP,personal journal MCP server,journal app for ChatGPT,Claude journal integration,journal app for AI reflection" %>
 
@@ -7,7 +7,7 @@
   <script type="application/ld+json"><%= raw(json_escape({
     "@context": "https://schema.org",
     "@type": "Article",
-    headline: "Best Journaling Apps with MCP / Claude & ChatGPT Connectors",
+    headline: "Best Journaling Apps with MCP / Claude and ChatGPT Connectors",
     description: content_for(:description),
     url: "#{ApplicationHelper.site_public_base_url}/best-journaling-apps-with-mcp",
     dateModified: "2026-07-24",
@@ -52,7 +52,7 @@
           prompts = [
             { bold: true,  text: "Summarize my last month's journal entries and cite the dates behind each theme." },
             { bold: false, text: "Find every time I mentioned burnout. What situations usually came before it?" },
-            { bold: true,  text: "Using voice in my favorite AI app, help me process my day out loud—then save a clear journal entry for today with the key moments." },
+            { bold: true,  text: "Using voice in my favorite AI tool, help me process my day out loud—then save it as today's journal entry with the key moments." },
             { bold: false, text: "How has the way I write about my new job changed since January?" },
             { bold: false, text: "What people and places appeared most often in my journal this year?" },
             { bold: true,  text: "Talk me through tonight, then add this reflection to today's journal without overwriting anything already there." },

--- a/app/views/welcome/best_journaling_apps_with_mcp.html.erb
+++ b/app/views/welcome/best_journaling_apps_with_mcp.html.erb
@@ -1,16 +1,16 @@
-<% content_for :title, "Best Journaling Apps with MCP for ChatGPT and Claude" %>
-<% content_for :social_title, "Best journaling apps with MCP for ChatGPT and Claude" %>
-<% content_for :description, "A practical guide to journaling apps with vendor-supported MCP integrations, including Dabble Me and Day One, setup differences, security, and AI reflection prompts." %>
-<% content_for :keywords, "best journaling apps with MCP,AI journal with MCP,personal journal MCP server,journal app for ChatGPT,Claude journal integration,journal app for AI reflection" %>
+<% content_for :title, "Best Journaling Apps with MCP / Claude & ChatGPT Connectors" %>
+<% content_for :social_title, "Best journaling apps with MCP / Claude & ChatGPT Connectors" %>
+<% content_for :description, "A practical guide to journaling apps with vendor-supported MCP integrations for Claude and ChatGPT, including Dabble Me and Day One, setup differences, security, and AI reflection prompts." %>
+<% content_for :keywords, "best journaling apps with MCP,Claude ChatGPT connectors,AI journal with MCP,personal journal MCP server,journal app for ChatGPT,Claude journal integration,journal app for AI reflection" %>
 
 <% content_for :head do %>
   <script type="application/ld+json"><%= raw(json_escape({
     "@context": "https://schema.org",
     "@type": "Article",
-    headline: "Best Journaling Apps with MCP for ChatGPT and Claude",
+    headline: "Best Journaling Apps with MCP / Claude & ChatGPT Connectors",
     description: content_for(:description),
     url: "#{ApplicationHelper.site_public_base_url}/best-journaling-apps-with-mcp",
-    dateModified: "2026-07-23",
+    dateModified: "2026-07-24",
     author: { "@type": "Organization", name: "Dabble Dev LLC" }
   }.to_json)) %></script>
 <% end %>
@@ -19,7 +19,10 @@
   <div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
     <header class="text-center">
       <p class="text-sm font-semibold tracking-wide text-accent uppercase">Buyer’s guide · July 2026</p>
-      <h1 class="mt-4 font-serif text-4xl sm:text-5xl tracking-tight">Best journaling apps with MCP</h1>
+      <h1 class="mt-4 font-serif text-4xl sm:text-5xl tracking-tight">
+        Best journaling apps with MCP
+        <span class="block mt-3 font-sans text-xl sm:text-2xl font-medium tracking-normal text-muted">Claude &amp; ChatGPT Connectors</span>
+      </h1>
       <p class="mt-5 text-lg leading-relaxed text-muted max-w-3xl mx-auto">
         The useful question is not simply whether a journal “has AI.” It is whether the journal offers a clear,
         permissioned Model Context Protocol server that your chosen AI assistant can use for real retrieval and writing.
@@ -36,6 +39,35 @@
         <li><strong class="text-primary">Revocation:</strong> there is a documented way to remove access.</li>
         <li><strong class="text-primary">Data clarity:</strong> users are told that retrieved text reaches the AI provider.</li>
       </ul>
+    </section>
+
+    <section class="mt-16" id="example-prompts">
+      <h2 class="font-serif text-3xl text-primary">Prompts that show why MCP matters</h2>
+      <p class="mt-3 text-muted max-w-3xl">
+        Ask in plain language inside Claude, ChatGPT, or another MCP-compatible AI app. The strongest prompts below
+        are emphasized so you can scan for common starting points—including voice-first journaling on the go.
+      </p>
+      <div class="mt-6 grid sm:grid-cols-2 gap-5">
+        <%
+          prompts = [
+            { bold: true,  text: "Summarize my last month's journal entries and cite the dates behind each theme." },
+            { bold: false, text: "Find every time I mentioned burnout. What situations usually came before it?" },
+            { bold: true,  text: "Using voice in my favorite AI app, help me process my day out loud—then save a clear journal entry for today with the key moments." },
+            { bold: false, text: "How has the way I write about my new job changed since January?" },
+            { bold: false, text: "What people and places appeared most often in my journal this year?" },
+            { bold: true,  text: "Talk me through tonight, then add this reflection to today's journal without overwriting anything already there." },
+            { bold: false, text: "Show me entries tagged #gratitude from the last six months." },
+            { bold: false, text: "Compare how I wrote about sleep in March versus June. What changed?" },
+            { bold: true,  text: "Find every time I mentioned burnout, then help me draft tomorrow's intention as a new journal entry." },
+            { bold: false, text: "List entries from last week and pull out anything that still feels unfinished." }
+          ]
+        %>
+        <% prompts.each do |prompt| %>
+          <blockquote class="card p-5 text-sm leading-relaxed <%= prompt[:bold] ? 'font-semibold text-primary' : 'text-muted' %>">
+            “<%= prompt[:text] %>”
+          </blockquote>
+        <% end %>
+      </div>
     </section>
 
     <section class="mt-16">
@@ -131,22 +163,6 @@
         <li>Which text is sent to the AI provider when you request a summary or search?</li>
         <li>Can you see clear tool names and descriptions before approving access?</li>
       </ol>
-    </section>
-
-    <section class="mt-16">
-      <h2 class="font-serif text-3xl text-primary">Prompts that show why MCP matters</h2>
-      <div class="mt-6 grid sm:grid-cols-2 gap-5">
-        <% [
-          "Summarize my last month's journal entries and cite the dates behind each theme.",
-          "Find every time I mentioned burnout. What situations usually came before it?",
-          "How has the way I write about my new job changed since January?",
-          "What people and places appeared most often in my journal this year?",
-          "Show me entries tagged #gratitude from the last six months.",
-          "Add this reflection to today's journal, but do not overwrite anything already there."
-        ].each do |prompt| %>
-          <blockquote class="card p-5 text-sm text-muted">“<%= prompt %>”</blockquote>
-        <% end %>
-      </div>
     </section>
 
     <section class="mt-16 card p-8 text-center">

--- a/app/views/welcome/mcp_server.html.erb
+++ b/app/views/welcome/mcp_server.html.erb
@@ -356,7 +356,7 @@ structured_data = {
       </p>
       <div class="mt-6 flex flex-col sm:flex-row justify-center gap-3">
         <a class="btn btn-secondary" href="<%= day_one_ai_journaling_path %>">Dabble Me vs. Day One</a>
-        <a class="btn btn-secondary" href="<%= best_journaling_apps_with_mcp_path %>">Best journaling apps with MCP</a>
+        <a class="btn btn-secondary" href="<%= best_journaling_apps_with_mcp_path %>">Best journaling apps with MCP / Claude &amp; ChatGPT</a>
       </div>
     </section>
   </div>

--- a/app/views/welcome/mcp_server.html.erb
+++ b/app/views/welcome/mcp_server.html.erb
@@ -311,8 +311,8 @@ structured_data = {
           ["Create a dated entry", "Create a journal entry for July 17, 2026: Dinner with old friends reminded me how much I value staying connected."]
         ].each do |title, prompt| %>
           <div class="card p-5">
-            <h3 class="font-semibold text-sm text-primary"><%= title %></h3>
-            <blockquote class="mt-2 text-sm text-muted">“<%= prompt %>”</blockquote>
+            <h3 class="font-sans font-semibold text-base tracking-tight text-primary"><%= title %></h3>
+            <blockquote class="mt-2 text-sm leading-relaxed text-muted">“<%= prompt %>”</blockquote>
           </div>
         <% end %>
       </div>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,7 +6,7 @@
 
 - [Dabble Me MCP Server](https://dabble.me/mcp-server): Supported clients, setup, OAuth authentication, permissions, live tool reference, technical metadata, privacy notes, and example prompts. <!-- pragma: allowlist secret -->
 - [Dabble Me vs. Day One for AI journaling](https://dabble.me/dabble-me-vs-day-one-ai-journaling): A balanced remote-vs-local MCP comparison. <!-- pragma: allowlist secret -->
-- [Best journaling apps with MCP](https://dabble.me/best-journaling-apps-with-mcp): Evaluation criteria and current vendor-supported options. <!-- pragma: allowlist secret -->
+- [Best journaling apps with MCP / Claude & ChatGPT Connectors](https://dabble.me/best-journaling-apps-with-mcp): Evaluation criteria, example prompts, and current vendor-supported options. <!-- pragma: allowlist secret -->
 - [Privacy policy](https://dabble.me/privacy): How Dabble Me stores journal data and handles connected apps. <!-- pragma: allowlist secret -->
 - [Support](https://dabble.me/support): Product FAQs. <!-- pragma: allowlist secret -->
 

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -8,6 +8,14 @@ describe 'Pages' do
     expect(page).to have_title 'Dabble me. Private email journaling & daily reflection.'
   end
 
+  it 'groups Support beneath Pricing in the footer' do
+    visit root_path
+
+    footer_lists = page.all('footer ul')
+    expect(footer_lists.first.all('a').map(&:text)).to eq(%w[Home Features Pricing Support])
+    expect(footer_lists.second).not_to have_link('Support')
+  end
+
   it 'has correct title for FAQs page' do
     visit support_path
     expect(page).to have_title 'Support — Dabble me.'

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -77,10 +77,17 @@ describe 'Pages' do
   it 'publishes a guide to journaling apps with MCP' do
     visit best_journaling_apps_with_mcp_path
 
-    expect(page).to have_title 'Best Journaling Apps with MCP for ChatGPT and Claude — Dabble me.'
+    expect(page).to have_title 'Best Journaling Apps with MCP / Claude & ChatGPT Connectors — Dabble me.'
+    expect(page).to have_content 'Best journaling apps with MCP'
+    expect(page).to have_content 'Claude & ChatGPT Connectors'
     expect(page).to have_content 'How this guide evaluates an AI journal with MCP'
+    expect(page).to have_content 'Prompts that show why MCP matters'
+    expect(page).to have_content 'Using voice in my favorite AI app, help me process my day out loud'
     expect(page).to have_content 'Dabble Me'
     expect(page).to have_content 'Day One'
     expect(page).to have_content 'Find every time I mentioned burnout'
+
+    page_text = page.text
+    expect(page_text.index('Prompts that show why MCP matters')).to be < page_text.index('1. Dabble Me')
   end
 end

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -77,12 +77,12 @@ describe 'Pages' do
   it 'publishes a guide to journaling apps with MCP' do
     visit best_journaling_apps_with_mcp_path
 
-    expect(page).to have_title 'Best Journaling Apps with MCP / Claude & ChatGPT Connectors — Dabble me.'
+    expect(page).to have_title 'Best Journaling Apps with MCP / Claude and ChatGPT Connectors — Dabble me.'
     expect(page).to have_content 'Best journaling apps with MCP'
     expect(page).to have_content 'Claude & ChatGPT Connectors'
     expect(page).to have_content 'How this guide evaluates an AI journal with MCP'
     expect(page).to have_content 'Prompts that show why MCP matters'
-    expect(page).to have_content 'Using voice in my favorite AI app, help me process my day out loud'
+    expect(page).to have_content 'Using voice in my favorite AI tool, help me process my day out loud'
     expect(page).to have_content 'Dabble Me'
     expect(page).to have_content 'Day One'
     expect(page).to have_content 'Find every time I mentioned burnout'

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -13,7 +13,7 @@ describe 'Pages' do
 
     footer_lists = page.all('footer ul')
     expect(footer_lists.first.all('a').map(&:text)).to eq(%w[Home Features Pricing Support])
-    expect(footer_lists.second).not_to have_link('Support')
+    expect(footer_lists[1]).not_to have_link('Support')
   end
 
   it 'has correct title for FAQs page' do

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -13,6 +13,15 @@ describe 'Pages' do
     expect(page).to have_title 'Support — Dabble me.'
   end
 
+  it 'explains mobile journaling through MCP AI connectors' do
+    visit support_path
+
+    expect(page).to have_content 'Is there a mobile app?'
+    expect(page).to have_content 'connect Dabble Me to ChatGPT, Claude, or another MCP-compatible AI app'
+    expect(page).to have_content 'use voice prompts where the AI app supports them'
+    expect(page).to have_link('connect Dabble Me to ChatGPT, Claude, or another MCP-compatible AI app', href: mcp_server_docs_path)
+  end
+
   it 'has correct title for Privacy page' do
     visit privacy_path
     expect(page).to have_title 'Privacy Policy — Dabble me.'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Strengthens the `/best-journaling-apps-with-mcp` guide so example prompts are easier to scan and more useful for Claude/ChatGPT connector users.

## Changes
- Retitle the page toward **Best journaling apps with MCP / Claude & ChatGPT Connectors** (visible H1 + subtitle; document title uses “and” to avoid HTML-entity title issues)
- Move the **Prompts that show why MCP matters** section above the Dabble Me / Day One reviews
- Expand prompt examples (including voice-first “process my day, then save as an entry” flows)
- Emphasize the strongest prompts with scattered bold styling for visual rhythm
- Update related CTA/link copy and feature coverage

## Test plan
- [x] `bundle exec rspec spec/features/welcome_spec.rb`
- [x] Visual check of `/best-journaling-apps-with-mcp` title, prompt placement, bold scattering, and voice prompt
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9155-0df5-7fb7-b54c-7f96d449230b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9155-0df5-7fb7-b54c-7f96d449230b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

