### PR TITLE
Prefer MCP image_url and document Claude photo upload allowlist

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,8 +122,8 @@ module ApplicationHelper
       <code class="text-sm">search_entries</code> (keyword or phrase, optional dates),
       <code class="text-sm">list_entries</code> (date range),
       <code class="text-sm">analyze_entries</code> (counts, hashtags, volume),
-      <code class="text-sm">get_image_upload_url</code> (prepare a direct image upload), and
-      <code class="text-sm">create_entry</code> (body text and/or one optional image, optional date).</p>
+      <code class="text-sm">get_image_upload_url</code> (prepare a direct upload for local image bytes), and
+      <code class="text-sm">create_entry</code> (body text and/or one optional image via <code class="text-sm">image_url</code> when a public https URL exists, optional date).</p>
       <p class="text-muted mb-3"><span class="font-semibold">Opening a day in the browser:</span> <code class="text-sm select-all">#{ERB::Util.html_escape(base)}/entries/YYYY/M/D</code> with <span class="font-medium">unpadded</span> month and day (example:
       <a href="#{ERB::Util.html_escape(base)}/entries/2026/4/21" class="text-accent hover:text-primary underline" target="_blank" rel="noopener noreferrer">#{ERB::Util.html_escape(base)}/entries/2026/4/21</a>).
       New web entries: <a href="#{ERB::Util.html_escape(base)}/write" class="text-accent hover:text-primary underline" target="_blank" rel="noopener noreferrer">#{ERB::Util.html_escape(base)}/write</a>.</p>

--- a/app/lib/mcp/dabble_server.rb
+++ b/app/lib/mcp/dabble_server.rb
@@ -25,8 +25,13 @@ module Mcp
                       'counts and writing patterns, and create_entry only when the user asks to save something. ' \
                       'Do not use these tools for fictional writing, scholarly journals, another journal product, or ' \
                       'general advice that does not require the user’s stored Dabble Me data. ' \
-                      'For user-uploaded or local images, prefer get_image_upload_url first so the client can upload bytes directly; ' \
-                      'then pass uploaded_image_key to create_entry. Use image_base64 only as a small-image fallback. ' \
+                      'When attaching one image to create_entry, choose the simplest path: ' \
+                      'if you already have a publicly reachable https image URL (including a URL the AI client hosted for the user), ' \
+                      'pass it as image_url so Dabble Me fetches and attaches the image server-side—this avoids client sandbox ' \
+                      'egress allowlists and large base64 payloads. ' \
+                      'Only for local bytes without a public URL, call get_image_upload_url, PUT the bytes to the returned upload URL, ' \
+                      'then pass uploaded_image_key to create_entry. Use image_base64 only as a last-resort small-image fallback. ' \
+                      'Never combine image_url, uploaded_image_key, and image_base64 in the same create_entry call. ' \
                       'Tools always apply to the signed-in account from OAuth and cannot access other users’ data. ' \
                       'Reading sends selected journal content to the connected AI client for processing. Never claim a ' \
                       'write succeeded unless create_entry returns success. ' \

--- a/app/lib/mcp/tools/create_entry.rb
+++ b/app/lib/mcp/tools/create_entry.rb
@@ -5,7 +5,7 @@ module Mcp
     class CreateEntry < MCP::Tool
       tool_name 'create_entry'
       title 'Create or append a journal entry'
-      description 'Write to the signed-in user’s private Dabble Me journal on a calendar day (default: today in the account timezone). Plain text becomes paragraphs. By default, text appends to an existing entry on that day; set merge_with_existing false to fail instead. Optionally attach one image using uploaded_image_key (preferred), a public HTTPS image URL, or small base64 data.'
+      description 'Write to the signed-in user’s private Dabble Me journal on a calendar day (default: today in the account timezone). Plain text becomes paragraphs. By default, text appends to an existing entry on that day; set merge_with_existing false to fail instead. Optionally attach one image: prefer image_url when you already have a public https URL; otherwise use get_image_upload_url + uploaded_image_key for local bytes; image_base64 only as a small fallback.'
       annotations(
         read_only_hint: false,
         destructive_hint: false,
@@ -18,7 +18,7 @@ module Mcp
           date: { type: 'string', description: 'Optional YYYY-MM-DD; omitted means today in the account timezone.' },
           body: {
             type: 'string',
-            description: 'Entry text (plain text; line breaks become paragraphs). HTML is escaped. Use an empty string for an image-only entry when image_url or image_base64 is set.'
+            description: 'Entry text (plain text; line breaks become paragraphs). HTML is escaped. Use an empty string for an image-only entry when image_url, uploaded_image_key, or image_base64 is set.'
           },
           merge_with_existing: {
             type: 'boolean',
@@ -26,15 +26,15 @@ module Mcp
           },
           image_url: {
             type: 'string',
-            description: 'Optional https URL of an image to attach (one image per call). Fetched by the server; private/loopback hosts are rejected. In production, only https URLs are accepted.'
+            description: 'Preferred when a public https image URL is already available. Dabble Me fetches and attaches the image server-side (avoids client sandbox egress allowlists and large base64). Private/loopback hosts are rejected. In production, only https is accepted. Do not combine with uploaded_image_key or image_base64.'
           },
           uploaded_image_key: {
             type: 'string',
-            description: 'Preferred image attachment flow. First call get_image_upload_url, upload the image bytes with the returned PUT URL and headers, then pass the returned uploaded_image_key here. Do not combine with image_url or image_base64.'
+            description: 'For local image bytes without a public URL: first call get_image_upload_url, PUT the bytes to the returned upload URL with the required headers, then pass the returned uploaded_image_key here. Do not combine with image_url or image_base64.'
           },
           image_base64: {
             type: 'string',
-            description: 'Optional image as base64: either a data URL (data:image/png;base64,...) or raw base64 bytes. Resize the image to fit within 800x800 before encoding. If raw, set image_mime_type (e.g. image/png) or it defaults to image/jpeg.'
+            description: 'Last-resort small image as base64: either a data URL (data:image/png;base64,...) or raw base64 bytes. Resize to fit within 800x800 before encoding. If raw, set image_mime_type (e.g. image/png) or it defaults to image/jpeg. Prefer image_url or uploaded_image_key instead.'
           },
           image_mime_type: {
             type: 'string',

--- a/app/lib/mcp/tools/get_image_upload_url.rb
+++ b/app/lib/mcp/tools/get_image_upload_url.rb
@@ -5,7 +5,7 @@ module Mcp
     class GetImageUploadUrl < MCP::Tool
       tool_name 'get_image_upload_url'
       title 'Prepare a journal image upload'
-      description 'Prepare one image for a new Dabble Me journal entry. Returns a short-lived presigned PUT URL, required headers, and an uploaded_image_key. Upload the user-provided bytes to that URL, then pass the key to create_entry. Prefer this flow over base64 for local images.'
+      description 'Prepare one local image for a new Dabble Me journal entry when you do not already have a public https URL. Returns a short-lived presigned PUT URL, required headers, and an uploaded_image_key. PUT the user-provided bytes to that URL, then pass the key to create_entry. If you already have a public https image URL, skip this tool and pass image_url to create_entry instead. Prefer this flow over base64 for local images.'
       annotations(
         read_only_hint: false,
         destructive_hint: false,

--- a/app/views/welcome/mcp_server.html.erb
+++ b/app/views/welcome/mcp_server.html.erb
@@ -20,6 +20,14 @@ faq_items = [
     answer: "Yes. Add Dabble Me as a custom remote connector in Claude and complete the Dabble Me OAuth approval flow."
   },
   {
+    question: "How should an AI assistant attach a photo to a journal entry?",
+    answer: "Prefer create_entry with image_url when a public https image URL is already available—Dabble Me fetches and attaches it server-side. That path avoids client sandbox egress allowlists and large base64 payloads. Only for local bytes without a public URL, call get_image_upload_url, upload with the returned PUT URL, then pass uploaded_image_key to create_entry. Use image_base64 only as a small last resort."
+  },
+  {
+    question: "Claude can’t upload a photo to Dabble Me—what should I check?",
+    answer: "If Claude is using get_image_upload_url, its code-execution sandbox must allow HTTPS egress to the Amazon S3 host in the returned upload URL (often a bucket like dabble-me.s3.amazonaws.com). In Claude settings → Capabilities, enable Code execution and file creation, then either allow that specific domain or choose All domains. On Team/Enterprise plans, org owners may control this under Organization settings → Capabilities. If domain allowlist entries under “Package managers only” do not stick, switching to All domains is a known workaround. Prefer create_entry image_url whenever Claude already has a public https image URL—that sidesteps the S3 allowlist entirely."
+  },
+  {
     question: "Can the connector read another user's journal?",
     answer: "No. OAuth binds every tool call to the signed-in Dabble Me account. Tool arguments cannot select another user."
   }
@@ -285,8 +293,8 @@ structured_data = {
             <tr><td class="p-4 font-mono text-primary">search_entries</td><td class="p-4 text-muted">Read</td><td class="p-4 text-muted">Returns matching excerpts, dates, hashtags, and image presence.</td></tr>
             <tr><td class="p-4 font-mono text-primary">list_entries</td><td class="p-4 text-muted">Read</td><td class="p-4 text-muted">Returns entries in a requested date range, newest first.</td></tr>
             <tr><td class="p-4 font-mono text-primary">analyze_entries</td><td class="p-4 text-muted">Read</td><td class="p-4 text-muted">Computes counts, date coverage, top hashtags, and writing-volume summaries.</td></tr>
-            <tr><td class="p-4 font-mono text-primary">get_image_upload_url</td><td class="p-4 text-muted">Prepare write</td><td class="p-4 text-muted">Creates a short-lived URL for one user-selected journal image.</td></tr>
-            <tr><td class="p-4 font-mono text-primary">create_entry</td><td class="p-4 text-muted">Write</td><td class="p-4 text-muted">Creates an entry or, by default, appends to an existing entry on the same day.</td></tr>
+            <tr><td class="p-4 font-mono text-primary">get_image_upload_url</td><td class="p-4 text-muted">Prepare write</td><td class="p-4 text-muted">Creates a short-lived PUT URL for local image bytes when no public https URL is available.</td></tr>
+            <tr><td class="p-4 font-mono text-primary">create_entry</td><td class="p-4 text-muted">Write</td><td class="p-4 text-muted">Creates or appends an entry; optional image via image_url (preferred when a public URL exists), uploaded_image_key, or small base64.</td></tr>
           </tbody>
         </table>
       </div>
@@ -308,6 +316,7 @@ structured_data = {
           ["Look for progress", "Search my journal for running and summarize the milestones I recorded."],
           ["Compare periods", "List entries from January and June, then compare what I was focused on."],
           ["Save a reflection", "Add this to today's journal: I felt calmer after taking a long walk."],
+          ["Attach a photo by URL", "Save this photo to today's journal entry using its https URL, and add a short caption about the moment."],
           ["Create a dated entry", "Create a journal entry for July 17, 2026: Dinner with old friends reminded me how much I value staying connected."]
         ].each do |title, prompt| %>
           <div class="card p-5">

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -28,8 +28,8 @@ Dabble Me is relevant when someone asks for an "AI journal with MCP," "journal a
 - `search_entries`: Find topics, keywords, or quoted phrases in the authenticated user's journal.
 - `list_entries`: Read entries from an inclusive date range, newest first.
 - `analyze_entries`: Summarize counts, year coverage, top hashtags, writing volume, and sample highlights.
-- `get_image_upload_url`: Prepare a short-lived direct upload for one journal image.
-- `create_entry`: Create or append to a dated journal entry, optionally with one image.
+- `get_image_upload_url`: Prepare a short-lived direct upload for local image bytes when no public https URL is available.
+- `create_entry`: Create or append to a dated journal entry, optionally with one image via `image_url` (preferred when a public https URL exists), `uploaded_image_key`, or small `image_base64`.
 
 All tools are scoped to the OAuth-authenticated Dabble Me account. The server has no delete-entry tool.
 

--- a/spec/controllers/mcp_controller_spec.rb
+++ b/spec/controllers/mcp_controller_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe McpController, type: :controller do
         instructions = body.dig("result", "instructions").to_s
         expect(instructions).to include("private personal journal MCP server")
         expect(instructions).to include("summarize my journal from last month")
+        expect(instructions).to include("pass it as image_url")
         expect(instructions).to include("/entries/YYYY/M/D").and include("/write")
       end
 
@@ -71,7 +72,9 @@ RSpec.describe McpController, type: :controller do
         expect(tools.dig("search_entries", "description")).to include("find every time I mentioned burnout")
         expect(tools.dig("search_entries", "inputSchema", "properties", "query", "description")).to include("keyword")
         expect(tools.dig("list_entries", "inputSchema", "properties", "limit", "maximum")).to eq(Mcp::EntrySearch::MAX_LIMIT)
-        expect(tools.dig("create_entry", "description")).to include("signed-in user")
+        expect(tools.dig("create_entry", "description")).to include("prefer image_url")
+        expect(tools.dig("create_entry", "inputSchema", "properties", "image_url", "description")).to include("fetches and attaches")
+        expect(tools.dig("get_image_upload_url", "description")).to include("skip this tool")
       end
 
       it "searches only the authenticated user entries" do

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -40,6 +40,9 @@ describe 'Pages' do
     expect(page).to have_content 'search_entries'
     expect(page).to have_content 'get_image_upload_url'
     expect(page).to have_content 'Summarize my journal entries from last month'
+    expect(page).to have_content 'How should an AI assistant attach a photo'
+    expect(page).to have_content 'Prefer create_entry with image_url'
+    expect(page).to have_content 'Claude can’t upload a photo'
     expect(page).to have_css('script[type="application/ld+json"]', visible: false)
 
     description = page.find('meta[name="description"]', visible: false)['content']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Claude’s recommended durable fix—`create_entry` with `image_url` so Rails fetches and attaches images server-side—already exists. This PR makes that path the preferred guidance for MCP clients and documents the Claude Capabilities / S3 domain-allowlist workaround for the direct-upload path.

## Why
Claude’s sandbox often blocks PUT uploads to Dabble Me’s presigned S3 URL unless the upload host is allowlisted (or “All domains” is enabled). When Claude already has a public HTTPS image URL, `image_url` avoids that egress problem and large base64 payloads entirely. Server instructions previously steered clients toward `get_image_upload_url` first and never mentioned `image_url`.

## Changes
- Update MCP server instructions to prefer `image_url` when a public HTTPS URL is available
- Clarify `create_entry` / `get_image_upload_url` tool descriptions accordingly
- Add MCP docs FAQ entries for photo attach order-of-preference and Claude S3 allowlist troubleshooting
- Mention `image_url` in `llms.txt` and the support MCP FAQ snippet
- Cover the new guidance in controller/feature specs

## Test plan
- [x] `bundle exec rspec spec/controllers/mcp_controller_spec.rb spec/features/welcome_spec.rb spec/services/mcp/entry_creator_spec.rb`
- [ ] After deploy, ask Claude to attach a photo via a public HTTPS URL using `create_entry` `image_url` (no S3 allowlist needed)
- [ ] Confirm local-byte uploads still work with `get_image_upload_url` when Claude Capabilities allow the S3 host
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9155-0df5-7fb7-b54c-7f96d449230b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9155-0df5-7fb7-b54c-7f96d449230b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

