### PR TITLE
Block libvips untrusted operations for image uploads

### DIFF
--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Dabble Me processes untrusted user images with libvips (CarrierWave::Vips,
+# CollageGenerator, ImageProcessing::Vips). libvips marks some loaders/savers as
+# "untrusted" / unfuzzed (Magick, SVG, PDF, JPEG 2000, JXL, etc.). Keep those
+# disabled process-wide so crafted uploads cannot exercise them.
+#
+# Supported formats (JPEG, PNG, GIF, WebP, HEIC/HEIF) use trusted loaders and
+# remain available. Requires libvips >= 8.13 and ruby-vips >= 2.2.1.
+#
+# Related: CVE-2026-66066 / GHSA-xr9x-r78c-5hrm (Active Storage path; Dabble Me
+# does not use Active Storage variants, but shares the same libvips surface).
+
+begin
+  require 'nokogiri'
+rescue LoadError
+  # Ensure nokogiri is loaded before vips, which also depends on libxml2.
+  # See https://github.com/sparklemotion/nokogiri/discussions/2746
+end
+
+require 'ruby-vips'
+
+unless Vips.respond_to?(:block_untrusted)
+  raise <<~ERROR.squish
+    libvips untrusted operations cannot be disabled. Blocking them requires
+    libvips 8.13+ and ruby-vips 2.2.1+. Upgrade libvips/ruby-vips before
+    processing untrusted image uploads.
+  ERROR
+end
+
+Vips.block_untrusted(true)

--- a/spec/initializers/vips_spec.rb
+++ b/spec/initializers/vips_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'libvips untrusted operation blocking' do
+  it 'enables block_untrusted at boot' do
+    expect(Vips).to respond_to(:block_untrusted)
+  end
+
+  it 'still loads trusted web formats' do
+    jpeg = Vips::Image.black(8, 8).jpegsave_buffer
+    png = Vips::Image.black(8, 8).pngsave_buffer
+    webp = Vips::Image.black(8, 8).webpsave_buffer
+    gif = Vips::Image.black(8, 8).gifsave_buffer
+
+    expect(Vips::Image.new_from_buffer(jpeg, '').width).to eq(8)
+    expect(Vips::Image.new_from_buffer(png, '').width).to eq(8)
+    expect(Vips::Image.new_from_buffer(webp, '').width).to eq(8)
+    expect(Vips::Image.new_from_buffer(gif, '').width).to eq(8)
+  end
+
+  it 'blocks untrusted SVG loading' do
+    svg = <<~SVG
+      <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+        <rect width="10" height="10"/>
+      </svg>
+    SVG
+
+    expect {
+      Vips::Image.new_from_buffer(svg, '')
+    }.to raise_error(Vips::Error)
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Defense-in-depth for Dabble Me’s libvips image pipeline (CarrierWave::Vips, collages, MCP/`ImageProcessing::Vips`).

[CVE-2026-66066](https://discuss.rubyonrails.org/t/cve-2026-66066-possible-arbitrary-file-read-and-remote-code-execution-in-active-storage-variant-processing/91432) targets Active Storage variant processing. Dabble Me does **not** use Active Storage for uploads, so that advisory’s Rails bump does not apply. We still process untrusted user images with the same underlying libvips surface, and nothing was calling `Vips.block_untrusted(true)`.

## Changes

- Add `config/initializers/vips.rb` to disable unfuzzed/untrusted libvips loaders and savers at boot (web + Sidekiq).
- Fail boot if libvips/ruby-vips are too old to honor the flag (`libvips` ≥ 8.13, `ruby-vips` ≥ 2.2.1).
- Spec covers trusted formats still loading and SVG (untrusted) being rejected.

## Expected impact

- Still works: JPEG, PNG, GIF, WebP, HEIC/HEIF
- Blocked: Magick-delegated / exotic formats (SVG, PDF, JPEG 2000, JXL, BMP/ICO/PSD via Magick, etc.) that Dabble Me does not support anyway

## Test plan

- [x] `bundle exec rspec spec/initializers/vips_spec.rb` (+ collage/uploader specs) — 11 examples, 0 failures
- [ ] Spot-check HEIC/JPEG upload + collage path still processes in staging/prod after deploy
- [ ] Confirm production libvips is ≥ 8.13 (required for the block API)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb25c-847a-7262-b8ca-e9ca6ded0317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb25c-847a-7262-b8ca-e9ca6ded0317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

