### PR TITLE
Normalize mixed Gmail paragraph breaks

### DIFF
--- a/app/lib/email_processor.rb
+++ b/app/lib/email_processor.rb
@@ -395,6 +395,7 @@ class EmailProcessor
     fragment = Nokogiri::HTML5.fragment(html)
     normalize_empty_html_blocks(fragment)
     normalize_html_text_nodes(fragment)
+    normalize_html_block_edge_breaks(fragment)
     trim_html_edge_breaks(fragment)
     fragment.css('a[href]').each { |link| link['target'] = '_blank' }
 
@@ -580,6 +581,35 @@ class EmailProcessor
       node.add_previous_sibling(Nokogiri::XML::Node.new('br', node.document)) if index < parts.length - 1
     end
     node.remove
+  end
+
+  # Gmail can encode the same blank line either as an empty block between
+  # paragraphs or as a <br> at the edge of a content block. Move edge breaks
+  # between block siblings so both representations render identically.
+  def normalize_html_block_edge_breaks(fragment)
+    fragment.css('blockquote,div,li,p').each do |block|
+      normalize_html_block_edge_break(block, :previous)
+      normalize_html_block_edge_break(block, :next)
+    end
+  end
+
+  def normalize_html_block_edge_break(block, direction)
+    edge_child = direction == :previous ? first_content_child(block) : last_content_child(block)
+    return unless edge_child&.name == 'br'
+
+    sibling = nearest_non_whitespace_sibling(block, direction)
+    return unless sibling&.element? && (sibling.name == 'br' || html_block_node?(sibling))
+
+    loop do
+      edge_child = direction == :previous ? first_content_child(block) : last_content_child(block)
+      break unless edge_child&.name == 'br'
+
+      edge_child.remove
+    end
+    return if sibling.name == 'br'
+
+    separator = Nokogiri::XML::Node.new('br', block.document)
+    direction == :previous ? block.add_previous_sibling(separator) : block.add_next_sibling(separator)
   end
 
   def trim_html_edge_breaks(fragment)

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -47,7 +47,14 @@ describe 'Day Entries' do
 
       rendered_entry = page.find('.s-scrollable')
       expect(rendered_entry.all(:xpath, './*').map(&:tag_name)).to eq(%w[div br div br div br div])
-      expect(rendered_entry).to have_text('First paragraph Second paragraph Third paragraph. Lorem ipsum Fourth paragraph. Lorem ipsum')
+      expect(rendered_entry.text.split("\n")).to eq(
+        [
+          'First paragraph',
+          'Second paragraph',
+          'Third paragraph. Lorem ipsum',
+          'Fourth paragraph. Lorem ipsum'
+        ]
+      )
     end
 
     it 'should show an entry stored at a non-midnight datetime' do

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -28,6 +28,28 @@ describe 'Day Entries' do
       expect(page).to have_content 'You need to login or sign up before continuing.'
     end
 
+    it 'renders one blank line for every mixed Gmail paragraph separator' do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\nSecond paragraph\n\nThird paragraph. Lorem ipsum\n\nFourth paragraph. Lorem ipsum",
+        vendor_specific: {
+          stripped_html: '<div>First paragraph<br></div><div>Second paragraph</div><div><br></div><div>Third paragraph.&nbsp;Lorem ipsum</div><div><br></div><div>Fourth paragraph.&nbsp;Lorem ipsum</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+      processed_entry = paid_user.entries.reload.first
+
+      sign_in paid_user
+      visit day_entry_url(year: processed_entry.date.year, month: processed_entry.date.month, day: processed_entry.date.day)
+
+      rendered_entry = page.find('.s-scrollable')
+      expect(rendered_entry.all(:xpath, './*').map(&:tag_name)).to eq(%w[div br div br div br div])
+      expect(rendered_entry).to have_text('First paragraph Second paragraph Third paragraph. Lorem ipsum Fourth paragraph. Lorem ipsum')
+    end
+
     it 'should show an entry stored at a non-midnight datetime' do
       sign_in user
       entry.update_columns(date: Time.utc(2026, 7, 17, 15, 30, 0), body: '<p>Afternoon journal entry</p>')

--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -149,6 +149,12 @@ describe EmailProcessor do
       expect(clean(html)).to eq('<div>First</div><br><div>Second</div>')
     end
 
+    it 'normalizes mixed Gmail paragraph separators to one blank line' do
+      html = '<div>First paragraph<br></div><div>Second paragraph</div><div><br></div><div>Third paragraph.&nbsp;Lorem ipsum</div><div><br></div><div>Fourth paragraph.&nbsp;Lorem ipsum</div>'
+
+      expect(clean(html)).to eq('<div>First paragraph</div><br><div>Second paragraph</div><br><div>Third paragraph.&nbsp;Lorem ipsum</div><br><div>Fourth paragraph.&nbsp;Lorem ipsum</div>')
+    end
+
     it 'removes leading and trailing empty blocks' do
       html = '<p><br></p><div>Content</div><p>&nbsp;</p>'
 

--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -71,6 +71,24 @@ describe EmailProcessor do
       expect(paid_user.entries.reload.first.body).to eq("<div>Blah blah blah. Blah blah.</div><br><div>Blah blah blah. Blah!</div>")
     end
 
+    it "stores consistent separators from mixed Gmail paragraph markup" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\nSecond paragraph\n\nThird paragraph. Lorem ipsum\n\nFourth paragraph. Lorem ipsum",
+        vendor_specific: {
+          stripped_html: '<div>First paragraph<br></div><div>Second paragraph</div><div><br></div><div>Third paragraph.&nbsp;Lorem ipsum</div><div><br></div><div>Fourth paragraph.&nbsp;Lorem ipsum</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq(
+        '<div>First paragraph</div><br><div>Second paragraph</div><br><div>Third paragraph.&nbsp;Lorem ipsum</div><br><div>Fourth paragraph.&nbsp;Lorem ipsum</div>'
+      )
+    end
+
     it "removes a trailing em-dash separator followed by a signature line" do
       paid_user.entries.destroy_all
       email = FactoryBot.build(
@@ -153,6 +171,61 @@ describe EmailProcessor do
       html = '<div>First paragraph<br></div><div>Second paragraph</div><div><br></div><div>Third paragraph.&nbsp;Lorem ipsum</div><div><br></div><div>Fourth paragraph.&nbsp;Lorem ipsum</div>'
 
       expect(clean(html)).to eq('<div>First paragraph</div><br><div>Second paragraph</div><br><div>Third paragraph.&nbsp;Lorem ipsum</div><br><div>Fourth paragraph.&nbsp;Lorem ipsum</div>')
+    end
+
+    describe 'paragraph separator variants' do
+      {
+        'a trailing break in the preceding block' => [
+          '<div>First<br></div><div>Second</div>',
+          '<div>First</div><br><div>Second</div>'
+        ],
+        'a leading break in the following block' => [
+          '<div>First</div><div><br>Second</div>',
+          '<div>First</div><br><div>Second</div>'
+        ],
+        'an explicit break between blocks' => [
+          '<div>First</div><br><div>Second</div>',
+          '<div>First</div><br><div>Second</div>'
+        ],
+        'an empty div between blocks' => [
+          '<div>First</div><div><br></div><div>Second</div>',
+          '<div>First</div><br><div>Second</div>'
+        ],
+        'an NBSP-only paragraph between blocks' => [
+          '<div>First</div><p>&nbsp;</p><div>Second</div>',
+          '<div>First</div><br><div>Second</div>'
+        ],
+        'duplicate trailing and empty-block separators' => [
+          '<div>First<br></div><div><br></div><div>Second</div>',
+          '<div>First</div><br><div>Second</div>'
+        ],
+        'multiple trailing breaks' => [
+          '<div>First<br><br></div><div>Second</div>',
+          '<div>First</div><br><div>Second</div>'
+        ],
+        'multiple consecutive empty blocks' => [
+          '<div>First</div><div><br></div><p>&nbsp;</p><div><br></div><div>Second</div>',
+          '<div>First</div><br><div>Second</div>'
+        ]
+      }.each do |description, (html, expected)|
+        it "normalizes #{description} to exactly one blank line" do
+          expect(clean(html)).to eq(expected)
+        end
+      end
+
+      it 'normalizes separators inside a Gmail wrapper' do
+        html = '<div><div>First<br></div><div>Second</div><div><br></div><div>Third</div></div>'
+
+        expect(clean(html)).to eq('<div><div>First</div><br><div>Second</div><br><div>Third</div></div>')
+      end
+
+      it 'does not invent a blank line between adjacent blocks' do
+        expect(clean('<div>First</div><div>Second</div>')).to eq('<div>First</div><div>Second</div>')
+      end
+
+      it 'preserves a single authored line break within a paragraph' do
+        expect(clean('<div>First line<br>Second line</div>')).to eq('<div>First line<br>Second line</div>')
+      end
     end
 
     it 'removes leading and trailing empty blocks' do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize Gmail edge `<br>` separators into standalone paragraph breaks
- preserve one consistent blank line across mixed Gmail HTML representations
- cover trailing, leading, explicit, empty-block, NBSP, duplicate, repeated, nested, and inline separator forms
- verify the full paid-user inbound path stores normalized HTML
- verify the entry page renders the exact `div/br` sequence and four text lines

## Verification
- `bundle exec rspec spec/models/email_processor_spec.rb spec/features/entries_spec.rb` — 39 examples, 0 failures
- `bundle exec rspec` — 236 examples, 0 failures, 1 expected pending

<a href="https://cursor.com/agents/bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsistent_email_paragraph_spacing.mp4"><img src="https://cursor.com/artifacts/c/art-786d2bf0-cdf1-4590-be63-66059d008b34" alt="consistent_email_paragraph_spacing.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

