### PR TITLE
Recover email content omitted by Mailgun

### DIFF
--- a/app/lib/email_processor.rb
+++ b/app/lib/email_processor.rb
@@ -15,6 +15,7 @@ class EmailProcessor
     @bcc = email.bcc
     @subject = to_utf8(email.subject)
     @stripped_html = email.vendor_specific.try(:[], :stripped_html)
+    @raw_html = email.raw_html
     @body = clean_message(email.body).presence || "No entry provided."
 
     @html = clean_html_version(@stripped_html)
@@ -108,7 +109,7 @@ class EmailProcessor
       date = parse_subject_for_date(@subject)
       existing_entry = @user.existing_entry(date.to_s)
       inspiration_id = parse_body_for_inspiration_id(@raw_body)
-      @body = @html.presence if @html.present? && @user.is_pro?
+      @body = preferred_pro_body if @user.is_pro?
 
       if existing_entry.present?
         existing_entry.original_email = @inbound_email_params
@@ -403,6 +404,32 @@ class EmailProcessor
     return unless html.present?
 
     html
+  end
+
+  def normalized_visible_text(html)
+    fragment = Nokogiri::HTML5.fragment(html.to_s)
+    fragment.css('br').each { |node| node.replace(Nokogiri::XML::Text.new(' ', node.document)) }
+    fragment.css(HTML_BLOCK_ELEMENTS.join(',')).each do |node|
+      node.add_next_sibling(Nokogiri::XML::Text.new(' ', node.document))
+    end
+    fragment.text.unicode_normalize(:nfkc).gsub(/\s+/, ' ').strip
+  end
+
+  def preferred_pro_body
+    return @body unless @html.present?
+
+    plain_text = normalized_visible_text(@body)
+    stripped_html_text = normalized_visible_text(@html)
+    stripped_html_is_strict_prefix = plain_text.start_with?(stripped_html_text) &&
+                                     plain_text != stripped_html_text
+
+    return @html unless stripped_html_is_strict_prefix
+
+    cleaned_raw_html = clean_html_version(@raw_html)
+    return cleaned_raw_html if cleaned_raw_html.present? &&
+                               normalized_visible_text(cleaned_raw_html) == plain_text
+
+    @body
   end
 
   def collage_from_attachments(attachments, existing_image_url: nil)

--- a/app/lib/email_processor.rb
+++ b/app/lib/email_processor.rb
@@ -15,7 +15,6 @@ class EmailProcessor
     @bcc = email.bcc
     @subject = to_utf8(email.subject)
     @stripped_html = email.vendor_specific.try(:[], :stripped_html)
-    @raw_html = email.raw_html
     @body = clean_message(email.body).presence || "No entry provided."
 
     @html = clean_html_version(@stripped_html)
@@ -424,10 +423,6 @@ class EmailProcessor
                                      plain_text != stripped_html_text
 
     return @html unless stripped_html_is_strict_prefix
-
-    cleaned_raw_html = clean_html_version(@raw_html)
-    return cleaned_raw_html if cleaned_raw_html.present? &&
-                               normalized_visible_text(cleaned_raw_html) == plain_text
 
     @body
   end

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -72,10 +72,16 @@ describe 'Day Entries' do
       EmailProcessor.new(email).process
       processed_entry = paid_user.entries.reload.first
 
+      expect(processed_entry.body).to eq(
+        '<div>First paragraph<br><br>Second paragraph<br><br>Third paragraph<br><br>Fourth paragraph</div>'
+      )
+
       sign_in paid_user
       visit day_entry_url(year: processed_entry.date.year, month: processed_entry.date.month, day: processed_entry.date.day)
 
       rendered_entry = page.find('.s-scrollable')
+      rendered_body = rendered_entry.find(:xpath, './div')
+      expect(rendered_body.all(:xpath, './br').map(&:tag_name)).to eq(%w[br br br br br br])
       expect(rendered_entry).to have_text('First paragraph')
       expect(rendered_entry).to have_text('Second paragraph')
       expect(rendered_entry).to have_text('Third paragraph')

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -57,6 +57,32 @@ describe 'Day Entries' do
       )
     end
 
+    it 'renders all authored paragraphs when Mailgun stripped HTML is truncated' do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\nSecond paragraph\n\nThird paragraph\n\nFourth paragraph",
+        raw_html: '<div dir="ltr"><div>First paragraph<br><div class="gmail_quote"><div dir="ltr"><div><br></div><div>Second paragraph</div><div><br></div><div>Third paragraph</div><div><br></div><div>Fourth paragraph</div></div></div></div><div class="gmail_signature"><div><br>--<br></div><div>Sender signature</div></div></div>',
+        vendor_specific: {
+          stripped_html: '<div><div>First paragraph</div></div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+      processed_entry = paid_user.entries.reload.first
+
+      sign_in paid_user
+      visit day_entry_url(year: processed_entry.date.year, month: processed_entry.date.month, day: processed_entry.date.day)
+
+      rendered_entry = page.find('.s-scrollable')
+      expect(rendered_entry).to have_text('First paragraph')
+      expect(rendered_entry).to have_text('Second paragraph')
+      expect(rendered_entry).to have_text('Third paragraph')
+      expect(rendered_entry).to have_text('Fourth paragraph')
+      expect(rendered_entry).not_to have_text('Sender signature')
+    end
+
     it 'should show an entry stored at a non-midnight datetime' do
       sign_in user
       entry.update_columns(date: Time.utc(2026, 7, 17, 15, 30, 0), body: '<p>Afternoon journal entry</p>')

--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -56,6 +56,75 @@ describe EmailProcessor do
       expect(paid_user.entries.reload.first.body).to eq("<p>I am great</p><p>Here's a link: <a href=\"https://www.google.com\" target=\"_blank\">https://www.google.com</a></p>")
     end
 
+    it "recovers a complete paid entry when Mailgun stripped HTML loses nested authored paragraphs" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "FIRST PARAGRAPH\n\nSECOND PARAGRAPH\n\nTHIRD PARAGRAPH with NBSP\n\nFOURTH PARAGRAPH with NBSP",
+        raw_html: '<div dir="ltr"><div>FIRST PARAGRAPH<br><div class="gmail_quote"><div dir="ltr"><div class="gmail_quote"><div dir="ltr"><div><br></div><div>SECOND PARAGRAPH</div><div><br></div><div>THIRD PARAGRAPH with&nbsp;NBSP</div><div><br></div><div>FOURTH PARAGRAPH with&nbsp;NBSP</div></div></div></div></div></div><div><div dir="ltr" class="gmail_signature" data-smartmail="gmail_signature"><div dir="ltr"><div><br>--<br></div><div><b>Paul Arterburn</b></div></div></div></div></div>',
+        vendor_specific: {
+          stripped_html: '<div><div>FIRST PARAGRAPH</div></div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      saved_body = paid_user.entries.reload.first.body
+      expect(saved_body).to include('FIRST PARAGRAPH', 'SECOND PARAGRAPH', 'THIRD PARAGRAPH with&nbsp;NBSP', 'FOURTH PARAGRAPH with&nbsp;NBSP')
+      expect(saved_body).not_to include('Paul Arterburn')
+    end
+
+    it "prefers complete stripped HTML for a normal paid entry" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "Complete rich reply",
+        raw_html: "<div>Complete rich reply</div>",
+        vendor_specific: {
+          stripped_html: "<div>Complete <strong>rich</strong> reply</div>"
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq("<div>Complete <strong>rich</strong> reply</div>")
+    end
+
+    it "rejects raw HTML with quoted history and preserves the complete plain reply" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "FIRST PARAGRAPH\n\nSECOND PARAGRAPH",
+        raw_html: '<div>FIRST PARAGRAPH</div><div>SECOND PARAGRAPH</div><blockquote>QUOTED HISTORY</blockquote>',
+        vendor_specific: {
+          stripped_html: '<div>FIRST PARAGRAPH</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq("<div>FIRST PARAGRAPH<br><br>SECOND PARAGRAPH</div>")
+    end
+
+    it "preserves the complete plain reply when raw HTML is unavailable" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "FIRST PARAGRAPH\n\nSECOND PARAGRAPH",
+        vendor_specific: {
+          stripped_html: '<div>FIRST PARAGRAPH</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq("<div>FIRST PARAGRAPH<br><br>SECOND PARAGRAPH</div>")
+    end
+
     it "preserves blank lines between HTML email paragraphs" do
       paid_user.entries.destroy_all
       email = FactoryBot.build(

--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -71,7 +71,10 @@ describe EmailProcessor do
       EmailProcessor.new(email).process
 
       saved_body = paid_user.entries.reload.first.body
-      expect(saved_body).to include('FIRST PARAGRAPH', 'SECOND PARAGRAPH', 'THIRD PARAGRAPH with&nbsp;NBSP', 'FOURTH PARAGRAPH with&nbsp;NBSP')
+      expect(saved_body).to eq(
+        '<div>FIRST PARAGRAPH<br><br>SECOND PARAGRAPH<br><br>THIRD PARAGRAPH with NBSP<br><br>FOURTH PARAGRAPH with NBSP</div>'
+      )
+      expect(saved_body.scan('<br><br>').size).to eq(3)
       expect(saved_body).not_to include('Paul Arterburn')
     end
 
@@ -99,6 +102,23 @@ describe EmailProcessor do
         to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
         body: "FIRST PARAGRAPH\n\nSECOND PARAGRAPH",
         raw_html: '<div>FIRST PARAGRAPH</div><div>SECOND PARAGRAPH</div><blockquote>QUOTED HISTORY</blockquote>',
+        vendor_specific: {
+          stripped_html: '<div>FIRST PARAGRAPH</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq("<div>FIRST PARAGRAPH<br><br>SECOND PARAGRAPH</div>")
+    end
+
+    it "does not fall back to raw HTML when stripped HTML is truncated" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "FIRST PARAGRAPH\n\nSECOND PARAGRAPH",
+        raw_html: '<div><strong>FIRST PARAGRAPH</strong></div><div>SECOND PARAGRAPH</div>',
         vendor_specific: {
           stripped_html: '<div>FIRST PARAGRAPH</div>'
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- detect when Mailgun `stripped-html` is only a prefix of the complete trimmed plain reply
- use the already-cleaned complete plain reply for anomalous truncated HTML, avoiding malformed Gmail nesting and quoted-history leakage
- preserve rich stripped HTML for normal complete messages
- enforce exactly three identical `<br><br>` paragraph separators for the reported four-paragraph case
- cover persistence, quoted raw HTML, missing raw HTML, rendered DOM, and signature removal

## Verification
- `bundle exec rspec spec/models/email_processor_spec.rb spec/features/entries_spec.rb` — 45 examples, 0 failures
- `bundle exec rspec` — 243 examples, 0 failures, 1 expected pending
- CI `vm-job` and CodeFactor pass
- browser geometry measured paragraph deltas of approximately `38/40/38px` (effectively uniform 40px spacing)

<a href="https://cursor.com/agents/bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funiform_recovered_email_spacing.mp4"><img src="https://cursor.com/artifacts/c/art-41365a5b-cf86-44ca-9c4c-ea3216ed73bd" alt="uniform_recovered_email_spacing.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

