### PR TITLE
Add Day One JSON ZIP importer

### DIFF
--- a/PROJECT_INTENT.md
+++ b/PROJECT_INTENT.md
@@ -22,7 +22,7 @@ Dabble Me was built as a **direct replacement for OhLife** — a much-loved emai
 
 - There's a dedicated `OhLife` import flow ([entries/import/ohlife](app/controllers/import_controller.rb)) including image-archive upload.
 - There's an SEO landing page at `/ohlife-alternative` ([welcome_controller.rb](app/controllers/welcome_controller.rb)).
-- Imported entries are tagged with `Inspiration.category = "OhLife"` so they're identifiable forever.
+- Imported entries are tagged with `Inspiration.category = "OhLife"` (and similarly Day One / Ahhlife / Trailmix) so they're identifiable forever.
 
 If you're modifying behavior around imports, scheduling, or the email reply format, **do not break OhLife parity unless explicitly asked** — that audience is part of the product's reason for existing.
 

--- a/PROJECT_INTENT.md
+++ b/PROJECT_INTENT.md
@@ -22,6 +22,7 @@ Dabble Me was built as a **direct replacement for OhLife** — a much-loved emai
 
 - There's a dedicated `OhLife` import flow ([entries/import/ohlife](app/controllers/import_controller.rb)) including image-archive upload.
 - There's an SEO landing page at `/ohlife-alternative` ([welcome_controller.rb](app/controllers/welcome_controller.rb)).
+- There's a Day One migration page at `/day-one-alternative` (import + email journaling), kept separate from the MCP comparison at `/dabble-me-vs-day-one-ai-journaling`.
 - Imported entries are tagged with `Inspiration.category = "OhLife"` (and similarly Day One / Ahhlife / Trailmix) so they're identifiable forever.
 
 If you're modifying behavior around imports, scheduling, or the email reply format, **do not break OhLife parity unless explicitly asked** — that audience is part of the product's reason for existing.

--- a/README.md
+++ b/README.md
@@ -69,13 +69,16 @@ rake
 
 The Admin emails are accounts that have access to the Admin Dropdown in the navbar (lock icon) that give you details into the number of entries and users in the system.
 
-### Inspirations and OhLife Importer
+### Inspirations and Importers
 
-If you want random bits of inspiration, you can load up different quotes in the Inspiration table to be shown above the New Posts page and at the bottom of emails. If you plan on using OhLife, the system will tag imported posts with ```inspiration_id``` of 1 - so create the first Inspiration with a category name of "OhLife".
+If you want random bits of inspiration, you can load up different quotes in the Inspiration table to be shown above the New Posts page and at the bottom of emails. Import sources are tagged via Inspiration categories — seed OhLife / Ahhlife / Day One / Trailmix rows (see `db/seeds.rb`), or the Day One importer will create its category on first use.
 
 ```ruby
 Inspiration.create(category: 'OhLife', body: 'Imported from OhLife')
+Inspiration.create(category: 'Day One', body: 'Imported from Day One')
 ```
+
+PRO users can import from OhLife (text + photo ZIP), Day One (JSON ZIP export), Ahhlife (JSON paste), and Trailmix.life (JSON upload) at `/entries/import`.
 
 =====
 
@@ -83,7 +86,7 @@ Inspiration.create(category: 'OhLife', body: 'Imported from OhLife')
 
 * Read past entries by month/year
 * Create new entries with simple formatting
-* OhLife Importer
+* Importers: OhLife, Day One, Ahhlife, Trailmix.life
 * Email: Reply-to-post new entries on days of the week you choose (with random past entries embedded)
 * Associate 1 image to a specific entry
 * Search with basic analytics around posting

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -376,7 +376,8 @@ strong {
       }
     }
 
-    .j-copy-to-clipboard {
+    .j-copy-to-clipboard,
+    .email-post-cta {
       background: $olive;
       color: white;
       border: none;
@@ -389,6 +390,8 @@ strong {
       }
       &:hover {
         background: darken($olive, 10%);
+        color: white;
+        text-decoration: none;
       }
     }
   }

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -14,6 +14,8 @@ class ImportController < ApplicationController
       import_ahhlife_entries(params[:entry][:text])
     elsif params[:type]&.downcase == "trailmix"
       enqueue_trailmix_import
+    elsif params[:type]&.downcase == "day_one"
+      enqueue_day_one_import
     else
       import_ohlife_entries(params[:entry][:text])
     end
@@ -64,6 +66,21 @@ class ImportController < ApplicationController
     FileUtils.rm_f(params[:json_file]&.tempfile&.path) if params[:json_file]
     flash[:alert] = e.message
     redirect_to import_path(type: "trailmix")
+  end
+
+  def enqueue_day_one_import
+    stored_path = ImportUploadStore.store!(
+      uploaded_file: params[:zip_file],
+      user_key: current_user.user_key,
+      kind: "day_one"
+    )
+    ImportDayOneJob.perform_later(current_user.id, stored_path)
+    flash[:notice] = "Day One import has started. You will receive an email when it is finished."
+    redirect_to entries_path
+  rescue ImportUploadStore::Error => e
+    FileUtils.rm_f(params[:zip_file]&.tempfile&.path) if params[:zip_file]
+    flash[:alert] = e.message
+    redirect_to import_path(type: "day_one")
   end
 
   def import_ohlife_entries(data)

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -38,6 +38,10 @@ class WelcomeController < ApplicationController
     # Comparison page for people choosing an MCP-enabled journal.
   end
 
+  def day_one_alternative
+    # SEO landing page for Day One users considering email journaling + import.
+  end
+
   def best_journaling_apps_with_mcp
     # Guide to vendor-supported journaling apps with MCP.
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -184,7 +184,7 @@ module ApplicationHelper
           },
           {
             q: "Can I import from OhLife or other services?",
-            a: "Yes! PRO members can visit the <a href='#{Rails.application.routes.url_helpers.import_path}' class='text-accent hover:text-primary underline'>Importer</a> to import entries from OhLife, Ahhlife, and Trailmix.life."
+            a: "Yes! PRO members can visit the <a href='#{Rails.application.routes.url_helpers.import_path}' class='text-accent hover:text-primary underline'>Importer</a> to import entries from OhLife, Day One, Ahhlife, and Trailmix.life."
           },
           {
             q: "Can I get a refund?",

--- a/app/jobs/import_day_one_job.rb
+++ b/app/jobs/import_day_one_job.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ImportDayOneJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(user_id, stored_path)
+    @user = User.find(user_id)
+    result = DayOneImporter.new(user: @user, zip_path: stored_path).import!
+    deliver_completion_email(result)
+  rescue StandardError => e
+    Sentry.capture_exception(e, extra: { user_id: user_id, stored_path: stored_path })
+    deliver_failure_email(e)
+  ensure
+    ImportUploadStore.cleanup!(stored_path)
+  end
+
+  private
+
+  def deliver_completion_email(result)
+    parts = []
+    parts << "Finished importing #{ActionController::Base.helpers.pluralize(result.imported, 'entry')} from Day One."
+    parts << "You can view them at #{::Rails.application.routes.url_helpers.entries_url}."
+
+    if result.skipped.present?
+      Sentry.capture_message("Day One import skipped entries", level: :info, extra: { skipped: result.skipped, user_id: @user.id })
+      parts << "Skipped: #{result.skipped.join('; ')}."
+    end
+
+    if result.errors.present?
+      Sentry.capture_message("Day One import errors", level: :info, extra: { errors: result.errors, user_id: @user.id })
+      parts << "Errors: #{result.errors.join('; ')}."
+    end
+
+    ActionMailer::Base.mail(
+      from: "Paul from Dabble Me <hello@#{ENV['MAIN_DOMAIN']}>",
+      to: @user.email,
+      subject: "Import of Day One entries is complete",
+      content_type: "text/html",
+      body: parts.join(" ")
+    ).deliver_later
+  end
+
+  def deliver_failure_email(error)
+    return unless @user
+
+    ActionMailer::Base.mail(
+      from: "Paul from Dabble Me <hello@#{ENV['MAIN_DOMAIN']}>",
+      to: @user.email,
+      subject: "Day One import failed",
+      content_type: "text/html",
+      body: "Your Day One import could not be completed (#{error.message}). Please try again with a Day One JSON ZIP export, or reply to this email for help."
+    ).deliver_later
+  end
+end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -240,7 +240,11 @@ class Entry < ActiveRecord::Base
   end
 
   def associate_inspiration
-    self.inspiration = nil unless self.inspiration.in? Inspiration.without_imports_or_email_or_tips
+    return if inspiration.blank?
+    # Keep import/source tags (OhLife, Day One, etc.) so importers can label origin.
+    return if inspiration.category.in?(Inspiration::IMPORT_CATEGORIES)
+
+    self.inspiration = nil unless inspiration.in?(Inspiration.without_imports_or_email_or_tips)
   end
 
   def strip_out_base64

--- a/app/models/inspiration.rb
+++ b/app/models/inspiration.rb
@@ -1,6 +1,8 @@
 class Inspiration < ActiveRecord::Base
+  IMPORT_CATEGORIES = ["OhLife", "Ahhlife", "Email", "Seed", "Trailmix", "Day One"].freeze
+
   has_many :entries
-  scope :without_imports_or_email, -> { where("category NOT IN (?)", ['OhLife', 'Ahhlife', 'Email', 'Seed', 'Trailmix']) }
+  scope :without_imports_or_email, -> { where("category NOT IN (?)", IMPORT_CATEGORIES) }
   scope :without_imports_or_email_or_tips, -> { without_imports_or_email.where("category != 'Tip'") }
   scope :writing_prompts, -> { where(category: "Question") }
 
@@ -8,7 +10,7 @@ class Inspiration < ActiveRecord::Base
   validates :body, presence: true
 
   def inspired_by
-    if ["OhLife", "Email", "Ahhlife", "Seed", "Trailmix"].include? category
+    if IMPORT_CATEGORIES.include?(category)
       "Source: #{category}"
     elsif category == "Tip"
       "Tip"

--- a/app/services/collage_generator.rb
+++ b/app/services/collage_generator.rb
@@ -284,6 +284,14 @@ class CollageGenerator
     return nil if redirects_left.negative?
     return nil if url.blank?
 
+    # Local filesystem paths (used by Day One ZIP import) bypass HTTP.
+    local_path = local_image_path(url)
+    if local_path
+      return File.binread(local_path) if File.file?(local_path)
+
+      return nil
+    end
+
     # Malformed strings (e.g. internal sentinels like "mailgun_collage:…" that
     # leaked out of the email processor) should be dropped silently rather than
     # paged to Sentry — they're a caller-contract problem, not a runtime fault
@@ -334,6 +342,17 @@ class CollageGenerator
   rescue StandardError => e
     Sentry.capture_exception(e, extra: { url: sanitize_url(url) })
     nil
+  end
+
+  def local_image_path(url)
+    path = url.to_s
+    if path.start_with?("file://")
+      path = path.delete_prefix("file://")
+    end
+    return nil unless path.start_with?("/")
+    return nil if path.include?("\0")
+
+    path
   end
 
   def sanitize_url(url)

--- a/app/services/day_one_importer.rb
+++ b/app/services/day_one_importer.rb
@@ -56,9 +56,13 @@ class DayOneImporter
         next if entry.name.include?("..")
         next if entry.name.include?("__MACOSX/")
 
-        dest = File.join(tmpdir, entry.name)
+        dest = File.expand_path(File.join(tmpdir, entry.name))
+        next unless dest.start_with?(File.expand_path(tmpdir) + File::SEPARATOR) || dest == File.expand_path(tmpdir)
+
         FileUtils.mkdir_p(File.dirname(dest))
-        entry.extract(dest) { true }
+        File.open(dest, "wb") do |f|
+          f.write(entry.get_input_stream.read)
+        end
       end
     end
   end

--- a/app/services/day_one_importer.rb
+++ b/app/services/day_one_importer.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "zip"
+
+# Imports a Day One JSON ZIP export into Dabble Me entries.
+#
+# Expected ZIP layout (Day One 2.x+):
+#   Journal.json          # or any *.json with an "entries" array
+#   photos/<md5>.jpeg     # optional media
+#   photos/<md5>.png
+#
+# Multiple Day One entries on the same calendar day are merged into one Dabble
+# entry (Dabble Me is one-entry-per-day). Existing Dabble entries for a date
+# are skipped. At most one image is attached per day (single photo, or a
+# collage of up to CollageGenerator::MAX_IMAGES photos).
+class DayOneImporter
+  MOMENT_EMBED = /!\[.*?\]\(dayone-moment:\/\/[^)]+\)/i
+  PHOTO_TYPES = {
+    "jpeg" => %w[.jpeg .jpg],
+    "jpg" => %w[.jpg .jpeg],
+    "png" => %w[.png],
+    "gif" => %w[.gif],
+    "heic" => %w[.heic .heif],
+    "heif" => %w[.heif .heic],
+    "webp" => %w[.webp]
+  }.freeze
+
+  Result = Struct.new(:imported, :skipped, :errors, keyword_init: true)
+
+  def initialize(user:, zip_path:)
+    @user = user
+    @zip_path = zip_path
+    @imported = 0
+    @skipped = []
+    @errors = []
+  end
+
+  def import!
+    Dir.mktmpdir("day_one_import") do |tmpdir|
+      extract_zip!(tmpdir)
+      json_paths = Dir.glob(File.join(tmpdir, "**", "*.json")).reject { |p| p.include?("/__MACOSX/") }
+      raise ArgumentError, "No JSON journal file found in the ZIP" if json_paths.empty?
+
+      json_paths.each { |path| import_json_file(path, tmpdir) }
+    end
+
+    Result.new(imported: @imported, skipped: @skipped, errors: @errors)
+  end
+
+  private
+
+  def extract_zip!(tmpdir)
+    Zip::File.open(@zip_path) do |zipfile|
+      zipfile.each do |entry|
+        next if entry.directory?
+        next if entry.name.include?("..")
+        next if entry.name.include?("__MACOSX/")
+
+        dest = File.join(tmpdir, entry.name)
+        FileUtils.mkdir_p(File.dirname(dest))
+        entry.extract(dest) { true }
+      end
+    end
+  end
+
+  def import_json_file(path, tmpdir)
+    data = JSON.parse(File.read(path))
+    entries = data["entries"]
+    unless entries.is_a?(Array)
+      @errors << "#{File.basename(path)}: missing entries array"
+      return
+    end
+
+    grouped = entries.group_by { |raw| entry_date(raw) }
+    grouped.each do |date, day_entries|
+      import_day(date, day_entries, tmpdir)
+    end
+  rescue JSON::ParserError => e
+    @errors << "#{File.basename(path)}: invalid JSON (#{e.message})"
+  end
+
+  def import_day(date, day_entries, tmpdir)
+    if date.blank?
+      @errors << "Entry missing creationDate"
+      return
+    end
+
+    if @user.existing_entry(date).present?
+      @skipped << "Entry already exists for #{date}"
+      return
+    end
+
+    bodies = day_entries.sort_by { |e| e["creationDate"].to_s }.filter_map { |e| format_body(e["text"]) }
+    body = bodies.join("<hr>")
+    if body.blank? && day_entries.none? { |e| Array(e["photos"]).any? }
+      @skipped << "Empty entry for #{date}"
+      return
+    end
+
+    entry = @user.entries.new(
+      date: date,
+      body: body.presence || "<p></p>",
+      inspiration: day_one_inspiration
+    )
+
+    photo_paths = collect_photo_paths(day_entries, tmpdir)
+    attach_photos!(entry, photo_paths)
+
+    if entry.save
+      @imported += 1
+    else
+      @errors << "#{date}: #{entry.errors.full_messages.to_sentence}"
+    end
+  rescue StandardError => e
+    @errors << "#{date}: #{e.message}"
+    Sentry.capture_exception(e, extra: { date: date, user_id: @user.id })
+  end
+
+  def entry_date(raw)
+    created = raw["creationDate"].presence
+    return nil if created.blank?
+
+    zone = Time.find_zone(raw["timeZone"].presence) || ActiveSupport::TimeZone["UTC"]
+    zone.parse(created).to_date
+  rescue ArgumentError, TypeError
+    Time.zone.parse(created).to_date
+  rescue StandardError
+    nil
+  end
+
+  def format_body(text)
+    cleaned = text.to_s.gsub(MOMENT_EMBED, "").strip
+    return nil if cleaned.blank?
+
+    html = markdown.render(cleaned)
+    html.gsub!(/\A(\s*<p>\s*<\/p>\s*)/, "")
+    html.gsub!(/(\s*<p>\s*<\/p>\s*)\z/, "")
+    html.presence
+  end
+
+  def markdown
+    @markdown ||= Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true, escape_html: true),
+      autolink: true,
+      tables: true,
+      fenced_code_blocks: true,
+      strikethrough: true,
+      no_intra_emphasis: true
+    )
+  end
+
+  def day_one_inspiration
+    @day_one_inspiration ||= Inspiration.find_or_create_by!(category: "Day One") do |inspiration|
+      inspiration.body = "Imported from Day One"
+    end
+  end
+
+  def collect_photo_paths(day_entries, tmpdir)
+    paths = []
+    day_entries.sort_by { |e| e["creationDate"].to_s }.each do |raw|
+      Array(raw["photos"]).sort_by { |p| p["orderInEntry"].to_i }.each do |photo|
+        path = resolve_photo_path(photo, tmpdir)
+        paths << path if path
+        break if paths.size >= CollageGenerator::MAX_IMAGES
+      end
+      break if paths.size >= CollageGenerator::MAX_IMAGES
+    end
+    paths
+  end
+
+  def resolve_photo_path(photo, tmpdir)
+    md5 = photo["md5"].to_s
+    return nil if md5.blank? || md5.include?("..") || md5.include?("/")
+
+    type = photo["type"].to_s.downcase.presence || "jpeg"
+    extensions = PHOTO_TYPES[type] || [".#{type}", ".jpeg", ".jpg", ".png"]
+
+    extensions.each do |ext|
+      candidate = File.join(tmpdir, "photos", "#{md5}#{ext}")
+      return candidate if File.file?(candidate)
+    end
+
+    # Some exports nest media under a journal folder or use unexpected extensions.
+    Dir.glob(File.join(tmpdir, "**", "#{md5}.*")).find do |path|
+      next if path.include?("__MACOSX/")
+      next if path.include?("..")
+
+      File.file?(path)
+    end
+  end
+
+  def attach_photos!(entry, photo_paths)
+    return if photo_paths.blank?
+
+    if photo_paths.one?
+      File.open(photo_paths.first, "rb") { |f| entry.image = f }
+      return
+    end
+
+    collage = CollageGenerator.new(urls: photo_paths, user: @user).tempfile
+    if collage
+      entry.image = collage
+    else
+      File.open(photo_paths.first, "rb") { |f| entry.image = f }
+    end
+  ensure
+    if defined?(collage) && collage
+      collage.close
+      collage.unlink
+    end
+  end
+end

--- a/app/services/import_upload_store.rb
+++ b/app/services/import_upload_store.rb
@@ -5,14 +5,20 @@
 class ImportUploadStore
   BASE_DIR = Rails.root.join("tmp", "imports").freeze
 
+  ZIP_CONTENT_TYPES = %w[
+    application/zip
+    application/x-zip-compressed
+    application/octet-stream
+  ].freeze
+
   ALLOWED = {
     "ohlife" => {
       extensions: %w[.zip].freeze,
-      content_types: %w[
-        application/zip
-        application/x-zip-compressed
-        application/octet-stream
-      ].freeze
+      content_types: ZIP_CONTENT_TYPES
+    }.freeze,
+    "day_one" => {
+      extensions: %w[.zip].freeze,
+      content_types: ZIP_CONTENT_TYPES
     }.freeze,
     "trailmix" => {
       extensions: %w[.json].freeze,

--- a/app/views/import/show.html.erb
+++ b/app/views/import/show.html.erb
@@ -1,5 +1,10 @@
-<% type = params[:type].present? ? params[:type].humanize : "OhLife" %>
+<% type = case params[:type]&.downcase
+          when "day_one" then "Day One"
+          when nil, "" then "OhLife"
+          else params[:type].humanize
+          end %>
 <% content_for :title, "Import #{type} to Dabble Me" %>
+<% add_class = current_user.is_free? ? "blur" : nil %>
 
 <% if type == "Ahhlife" %>
   <% format_placeholder = '{"Jul-2015": {"-JtqbI_fF_2348SFrMqPQ": {"content": "Your entry here...","timestamp": 1436486400000}}}' %>
@@ -11,7 +16,6 @@
 
 <div class="row">
   <% if current_user.is_free? %>
-    <% add_class = "blur" %>
     <div class="col-md-8 col-md-offset-2">
       <div class="alert alert-warning" style="min-height: 45px;">
         <%= link_to subscribe_path, class: "float-left", style: "margin-top: -7px;" do %>
@@ -77,6 +81,28 @@
         </i>
       </div>
     </div>
+
+  <% elsif params[:type]&.downcase == "day_one" %>
+    <div class="well col-md-8 col-md-offset-2 <%= add_class %>">
+      <%= form_tag(import_process_path(type: "day_one"), multipart: true, method: :put, style: "text-align: center; padding-top: 10px;") do %>
+        <div><%= label_tag 'zip_file', "Choose Day One JSON ZIP export" %></div>
+        <div style="margin: 20px 0;"><%= file_field_tag 'zip_file', class: "center", accept: ".zip,application/zip" %></div>
+        <%= submit_tag "Upload Day One ZIP", class: "btn btn-primary" %>
+        <div class="clearfix"></div>
+      <% end %>
+      <div class="center" style="padding-top: 30px;">
+        <p>
+          In Day One, export your journal as <strong>JSON</strong> and include media if you want photos imported.
+        </p>
+        <p>
+          <i>
+            Upload the ZIP Day One creates (it should contain a <code>.json</code> file and optional
+            <code>photos/</code> folder). Multiple entries on the same day are combined into one Dabble Me entry.
+            Existing Dabble Me entries for a date are left unchanged.
+          </i>
+        </p>
+      </div>
+    </div>
   <% else %>
     <%= form_for :entry, url: import_process_path(type: type), method: :put, html: { class: add_class } do |f| %>
       <div class="col-md-8 col-md-offset-2">
@@ -96,8 +122,10 @@
     Try other import formats:
     <%= link_to "AhhLife", import_path('ahhlife') %>
     &middot;
+    <%= link_to "Day One", import_path('day_one') %>
+    &middot;
     <%= link_to "OhLife", import_path('ohlife') %>
     &middot;
     <%= link_to "Trailmix.life", import_path('trailmix') %>
-  </div>      
+  </div>
 </div>

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -78,3 +78,17 @@
           - else
             %i Tip: Use
           hashtags throughout your entries and you'll see a tag cloud appear here making it easy to search for posts containing those hashtags.
+
+    .email-post-card
+      .email-post-flex
+        .email-post-content
+          %h3 Ask ChatGPT or Claude about your journal
+          %p.text-muted
+            Connect Dabble Me once, then ask things like “What was I writing about last spring?” or “When did I mention burnout?”
+          .email-address-box
+            %code Secure AI connector
+            = link_to mcp_server_docs_path, class: "email-post-cta", style: "text-decoration: none; display: inline-block;" do
+              %i.fa.fa-external-link
+              How to connect
+          .email-post-footer
+            You approve access each time an app connects. Nothing runs until you choose to. PRO feature.

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -86,7 +86,7 @@
           %p.text-muted
             Connect Dabble Me once, then ask things like “What was I writing about last spring?” or “When did I mention burnout?”
           .email-address-box
-            %code Secure AI connector
+            %code AI connector
             = link_to mcp_server_docs_path, class: "email-post-cta", style: "text-decoration: none; display: inline-block;" do
               %i.fa.fa-external-link
               How to connect

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -10,7 +10,7 @@
           =link_to "Support", support_path, title: "Support & FAQs", style: "font-size: 15px;"
           - if user_signed_in?
             &nbsp;&middot;&nbsp;
-            = link_to "MCP", mcp_server_docs_path, title: "Connect ChatGPT or Claude to your journal", style: "font-size: 15px;"
+            = link_to "AI Connector", mcp_server_docs_path, title: "Connect ChatGPT or Claude to your journal", style: "font-size: 15px;"
           &nbsp;&middot;&nbsp;
           = link_to "Privacy", privacy_path, title: "Privacy Policy", style: "font-size: 15px;"
           &nbsp;&middot;&nbsp;

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -8,6 +8,9 @@
           =link_to "Features", root_path(s: 0, anchor: "features"), title: "Features", style: "font-size: 15px;"
           &nbsp;&middot;&nbsp;
           =link_to "Support", support_path, title: "Support & FAQs", style: "font-size: 15px;"
+          - if user_signed_in?
+            &nbsp;&middot;&nbsp;
+            = link_to "MCP", mcp_server_docs_path, title: "Connect ChatGPT or Claude to your journal", style: "font-size: 15px;"
           &nbsp;&middot;&nbsp;
           = link_to "Privacy", privacy_path, title: "Privacy Policy", style: "font-size: 15px;"
           &nbsp;&middot;&nbsp;

--- a/app/views/welcome/_pro_features.html.erb
+++ b/app/views/welcome/_pro_features.html.erb
@@ -98,16 +98,16 @@
         </p>
       </div>
 
-      <!-- Secure AI Connector (MCP) -->
+      <!-- AI Connector -->
       <div class="card p-6 border-accent/30">
         <div class="w-10 h-10 rounded-lg bg-surface-elevated flex items-center justify-center mb-4">
           <svg class="h-5 w-5 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
           </svg>
         </div>
-        <h3 class="font-semibold text-base text-primary font-sans">Secure AI Connector</h3>
+        <h3 class="font-semibold text-base text-primary font-sans">AI Connector</h3>
         <p class="mt-2 text-muted text-sm">
-          Optional MCP for ChatGPT and Claude — you approve access, and nothing runs until you connect.
+          Optional AI connector for ChatGPT and Claude — you approve access, and nothing runs until you connect.
           No social features. No sharing. No algorithms. Your journal stays yours.
           <%= link_to "How to connect", mcp_server_docs_path, class: "text-accent hover:text-primary underline" %>.
         </p>

--- a/app/views/welcome/_pro_features.html.erb
+++ b/app/views/welcome/_pro_features.html.erb
@@ -98,16 +98,17 @@
         </p>
       </div>
 
-      <!-- MCP (Claude & compatible apps) -->
+      <!-- Secure AI Connector (MCP) -->
       <div class="card p-6 border-accent/30">
         <div class="w-10 h-10 rounded-lg bg-surface-elevated flex items-center justify-center mb-4">
           <svg class="h-5 w-5 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m9-13.5h-1.5m0 1.5h1.5m-18 0H3m18 0h1.5m-15 3.75H3m18 0h1.5m-9-9V9m0 6v1.5m0 0V9m0 6h1.5m-1.5 0h-1.5m1.5 0v1.5M15 9v1.5m0 0V9m0 6h1.5m-1.5 0h-1.5m1.5 0v1.5" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
           </svg>
         </div>
-        <h3 class="font-semibold text-base text-primary font-sans">MCP for Claude &amp; more</h3>
+        <h3 class="font-semibold text-base text-primary font-sans">Secure AI Connector</h3>
         <p class="mt-2 text-muted text-sm">
-          Connect compatible assistants over the Model Context Protocol to search, analyze, and add entries.
+          Optional MCP for ChatGPT and Claude — you approve access, and nothing runs until you connect.
+          No social features. No sharing. No algorithms. Your journal stays yours.
           <%= link_to "How to connect", mcp_server_docs_path, class: "text-accent hover:text-primary underline" %>.
         </p>
       </div>

--- a/app/views/welcome/_pro_features.html.erb
+++ b/app/views/welcome/_pro_features.html.erb
@@ -105,10 +105,9 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
           </svg>
         </div>
-        <h3 class="font-semibold text-base text-primary font-sans">AI Connector</h3>
+        <h3 class="font-semibold text-base text-primary font-sans">Always Private</h3>
         <p class="mt-2 text-muted text-sm">
-          Optional AI connector for ChatGPT and Claude — you approve access, and nothing runs until you connect.
-          No social features. No sharing. No algorithms. Your journal stays yours.
+          No social features. No sharing. No algorithms. Optional AI connector for ChatGPT and Claude — you approve access, and nothing runs until you connect. Your journal stays yours.
           <%= link_to "How to connect", mcp_server_docs_path, class: "text-accent hover:text-primary underline" %>.
         </p>
       </div>

--- a/app/views/welcome/best_journaling_apps_with_mcp.html.erb
+++ b/app/views/welcome/best_journaling_apps_with_mcp.html.erb
@@ -139,6 +139,7 @@
       <div class="mt-5 flex flex-wrap gap-3">
         <a href="https://dayoneapp.com/guides/day-one-for-mac/day-one-mcp-server/" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">Official Day One MCP guide</a>
         <a href="<%= day_one_ai_journaling_path %>" class="btn btn-secondary">Compare with Dabble Me</a>
+        <a href="<%= day_one_alternative_path %>" class="btn btn-secondary">Import Day One journals</a>
       </div>
     </section>
 

--- a/app/views/welcome/day_one_ai_journaling.html.erb
+++ b/app/views/welcome/day_one_ai_journaling.html.erb
@@ -10,7 +10,7 @@
     headline: "Dabble Me vs. Day One for AI Journaling and MCP",
     description: content_for(:description),
     url: "#{ApplicationHelper.site_public_base_url}/dabble-me-vs-day-one-ai-journaling",
-    dateModified: "2026-07-23",
+    dateModified: "2026-08-02",
     author: { "@type": "Organization", name: "Dabble Dev LLC" }
   }.to_json)) %></script>
 <% end %>

--- a/app/views/welcome/day_one_ai_journaling.html.erb
+++ b/app/views/welcome/day_one_ai_journaling.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Dabble Me vs. Day One for AI Journaling and MCP" %>
 <% content_for :social_title, "Dabble Me vs. Day One for AI journaling" %>
-<% content_for :description, "Compare Dabble Me and Day One for MCP-enabled AI journaling: remote vs. local setup, ChatGPT and Claude access, writing workflows, security, and best fit." %>
-<% content_for :keywords, "Dabble Me vs Day One AI journaling,Day One MCP alternative,AI journal with MCP,journal app for ChatGPT,Claude journal integration" %>
+<% content_for :description, "Compare Dabble Me and Day One AI connectors: remote vs. local MCP, mobile and desktop access, ChatGPT and Claude setup, writing workflows, security, and best fit." %>
+<% content_for :keywords, "Dabble Me vs Day One AI journaling,Day One MCP alternative,AI journal with MCP,journal app for ChatGPT,Claude journal integration,remote MCP vs local MCP" %>
 
 <% content_for :head do %>
   <script type="application/ld+json"><%= raw(json_escape({
@@ -21,12 +21,35 @@
       <p class="text-sm font-semibold tracking-wide text-accent uppercase">AI journaling comparison</p>
       <h1 class="mt-4 font-serif text-4xl sm:text-5xl tracking-tight">Dabble Me vs. Day One for AI journaling</h1>
       <p class="mt-5 text-lg leading-relaxed text-muted max-w-3xl mx-auto">
-        Both products now offer vendor-supported MCP access for ChatGPT, Claude, and other AI assistants.
-        The main difference is architectural: Dabble Me is a hosted, email-first remote MCP service, while Day One’s
-        official MCP server runs locally through the Day One app and CLI on a Mac.
+        Both products offer an official AI connector for ChatGPT, Claude, and other assistants.
+        The practical difference is <strong class="text-primary">remote vs. local</strong>: Dabble Me’s connector
+        lives in the cloud and works wherever you use ChatGPT or Claude — including on a phone —
+        while Day One’s connector runs on your Mac and is available when that desktop setup is running.
       </p>
-      <p class="mt-3 text-sm text-subtle">Feature information reviewed July 23, 2026.</p>
+      <p class="mt-3 text-sm text-subtle">Feature information reviewed August 2, 2026.</p>
     </header>
+
+    <section class="mt-14 card p-6 bg-accent/5 border-accent/20">
+      <h2 class="font-serif text-2xl text-primary">Remote connector vs. local connector</h2>
+      <div class="mt-4 grid sm:grid-cols-2 gap-5 text-sm text-muted">
+        <div>
+          <p class="font-semibold text-primary">Dabble Me — remote</p>
+          <p class="mt-2 leading-relaxed">
+            The AI connector is hosted by Dabble Me. You connect by URL once, approve access, and can use it
+            from the ChatGPT or Claude apps on <strong class="text-primary">mobile and desktop</strong> —
+            no Mac app or local process has to stay running.
+          </p>
+        </div>
+        <div>
+          <p class="font-semibold text-primary">Day One — local</p>
+          <p class="mt-2 leading-relaxed">
+            The AI connector runs on your computer through Day One for Mac and its CLI.
+            That means it is a <strong class="text-primary">desktop / Mac setup</strong>: it is not something you
+            carry with you as a phone-only connection the way a remote URL connector is.
+          </p>
+        </div>
+      </div>
+    </section>
 
     <section class="mt-14 overflow-x-auto card">
       <table class="w-full text-left text-sm">
@@ -38,6 +61,16 @@
           </tr>
         </thead>
         <tbody class="divide-y divide-subtle">
+          <tr>
+            <td class="p-4 font-medium text-primary">Connector type</td>
+            <td class="p-4 text-muted">Remote (cloud-hosted URL)</td>
+            <td class="p-4 text-muted">Local (runs on your Mac)</td>
+          </tr>
+          <tr>
+            <td class="p-4 font-medium text-primary">Where it works</td>
+            <td class="p-4 text-muted">Mobile and desktop ChatGPT / Claude apps</td>
+            <td class="p-4 text-muted">Desktop Mac setup — not a mobile-first connector</td>
+          </tr>
           <tr>
             <td class="p-4 font-medium text-primary">MCP transport</td>
             <td class="p-4 text-muted">Remote Streamable HTTP</td>
@@ -70,8 +103,8 @@
           </tr>
           <tr>
             <td class="p-4 font-medium text-primary">Best fit</td>
-            <td class="p-4 text-muted">Email-first writers who want a cloud-hosted Claude or ChatGPT journal connection</td>
-            <td class="p-4 text-muted">Mac users who want local MCP access to native Day One journals</td>
+            <td class="p-4 text-muted">Writers who want ChatGPT or Claude on phone and desktop without keeping a Mac process online</td>
+            <td class="p-4 text-muted">Mac users who want the connector to run locally against Day One journals on that computer</td>
           </tr>
         </tbody>
       </table>
@@ -80,9 +113,9 @@
     <section class="mt-16">
       <h2 class="font-serif text-3xl text-primary">Choose Dabble Me when…</h2>
       <ul class="mt-5 space-y-3 text-muted">
-        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You want a <strong class="text-primary">journal app for ChatGPT</strong> or Claude that connects by URL with no local MCP process.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You want a <strong class="text-primary">journal app for ChatGPT</strong> or Claude that works on <strong class="text-primary">mobile and desktop</strong> via a remote connector.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You do not want to leave a Mac app and CLI running for the AI connection to work.</span></li>
         <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>Email is the habit you already keep: prompts arrive in your inbox and replies become journal entries.</span></li>
-        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You use more than one operating system or do not want the integration tied to a Mac that must be available.</span></li>
         <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You want built-in aggregate reflection tools for counts, top hashtags, writing volume, and sample highlights.</span></li>
       </ul>
     </section>
@@ -90,8 +123,8 @@
     <section class="mt-14">
       <h2 class="font-serif text-3xl text-primary">Choose Day One when…</h2>
       <ul class="mt-5 space-y-3 text-muted">
-        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You already keep journals in Day One and use a Mac.</span></li>
-        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You prefer the MCP server to run locally and read the Day One data available on that computer.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You already keep journals in Day One and primarily use a Mac.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You prefer a <strong class="text-primary">local desktop connector</strong> that reads Day One data on that computer — accepting it is not a mobile-first setup.</span></li>
         <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You maintain multiple journals and want to authorize MCP access journal by journal.</span></li>
         <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>Native Apple apps are more important to you than an email-first workflow.</span></li>
       </ul>
@@ -100,7 +133,7 @@
     <section class="mt-14 card p-6 bg-accent/5 border-accent/20">
       <h2 class="font-serif text-2xl text-primary">Privacy trade-off: local server vs. remote service</h2>
       <p class="mt-3 text-sm leading-relaxed text-muted">
-        Day One’s MCP server makes its journal access locally on the Mac. Dabble Me’s server runs in Dabble Me’s hosted
+        Day One’s local connector keeps the MCP process on your Mac. Dabble Me’s remote connector runs in Dabble Me’s hosted
         environment and limits calls to the OAuth-authorized account. In either case, the AI client normally sends
         retrieved journal content to its model provider to answer your prompt. Review that provider’s privacy settings
         before connecting highly sensitive writing.
@@ -111,7 +144,7 @@
       <h2 class="font-serif text-2xl text-primary">Already writing in Day One?</h2>
       <p class="mt-3 text-sm leading-relaxed text-muted">
         If you want the habit in your inbox instead of (or alongside) Day One’s apps, Dabble Me can import a Day One
-        JSON ZIP export. That migration path is covered separately so this page can stay focused on MCP.
+        JSON ZIP export. That migration path is covered separately so this page can stay focused on AI connectors.
       </p>
       <a href="<%= day_one_alternative_path %>" class="mt-4 inline-block text-accent hover:text-primary underline">
         Day One alternative &amp; journal import →
@@ -142,11 +175,11 @@
     </section>
 
     <section class="mt-16 card p-8 text-center">
-      <h2 class="font-serif text-3xl text-primary">Try the email-first MCP journal</h2>
-      <p class="mt-3 text-muted">Build the writing habit first, then ask ChatGPT or Claude to help you reflect.</p>
+      <h2 class="font-serif text-3xl text-primary">Try the email-first AI journal</h2>
+      <p class="mt-3 text-muted">Build the writing habit first, then ask ChatGPT or Claude to help you reflect — on phone or desktop.</p>
       <div class="mt-6 flex flex-col sm:flex-row justify-center gap-3">
         <a href="<%= new_user_registration_path %>" class="btn btn-primary">Start with Dabble Me</a>
-        <a href="<%= mcp_server_docs_path %>" class="btn btn-secondary">Read the MCP setup guide</a>
+        <a href="<%= mcp_server_docs_path %>" class="btn btn-secondary">Read the AI connector setup guide</a>
       </div>
     </section>
   </div>

--- a/app/views/welcome/day_one_ai_journaling.html.erb
+++ b/app/views/welcome/day_one_ai_journaling.html.erb
@@ -107,6 +107,17 @@
       </p>
     </section>
 
+    <section class="mt-14 card p-6">
+      <h2 class="font-serif text-2xl text-primary">Already writing in Day One?</h2>
+      <p class="mt-3 text-sm leading-relaxed text-muted">
+        If you want the habit in your inbox instead of (or alongside) Day One’s apps, Dabble Me can import a Day One
+        JSON ZIP export. That migration path is covered separately so this page can stay focused on MCP.
+      </p>
+      <a href="<%= day_one_alternative_path %>" class="mt-4 inline-block text-accent hover:text-primary underline">
+        Day One alternative &amp; journal import →
+      </a>
+    </section>
+
     <section class="mt-14">
       <h2 class="font-serif text-3xl text-primary">Example prompts for either journal</h2>
       <div class="mt-5 grid sm:grid-cols-2 gap-5">

--- a/app/views/welcome/day_one_alternative.html.erb
+++ b/app/views/welcome/day_one_alternative.html.erb
@@ -1,0 +1,135 @@
+<% content_for :title, "Day One Alternative: Import Your Journal into Dabble Me" %>
+<% content_for :social_title, "Day One alternative — email journaling with Dabble Me" %>
+<% content_for :description, "Looking for a Day One alternative? Import your Day One JSON export into Dabble Me and keep journaling by email — private prompts, reply-to-post entries, and optional remote MCP for ChatGPT and Claude." %>
+<% content_for :keywords, "Day One alternative,import Day One journal,Day One JSON export,switch from Day One,email journaling alternative,Day One to Dabble Me" %>
+
+<% content_for :head do %>
+  <script type="application/ld+json"><%= raw(json_escape({
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: "Day One Alternative: Import Your Journal into Dabble Me",
+    description: content_for(:description),
+    url: "#{ApplicationHelper.site_public_base_url}/day-one-alternative",
+    dateModified: "2026-08-02",
+    author: { "@type": "Organization", name: "Dabble Dev LLC" }
+  }.to_json)) %></script>
+<% end %>
+
+<section class="py-12 lg:py-20">
+  <div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+    <header class="text-center">
+      <p class="text-sm font-semibold tracking-wide text-accent uppercase">Day One alternative</p>
+      <h1 class="mt-4 font-serif text-4xl sm:text-5xl tracking-tight">
+        Import Day One. Journal by email.
+      </h1>
+      <p class="mt-5 text-lg leading-relaxed text-muted max-w-3xl mx-auto">
+        Dabble Me is a private, email-first journal. Export your Day One journal as JSON, import the ZIP into Dabble Me PRO,
+        and keep writing by replying to a daily prompt — no new app to open every day.
+      </p>
+      <div class="mt-8 flex flex-col sm:flex-row justify-center gap-3">
+        <a href="<%= new_user_registration_path %>" class="btn btn-primary">Start free, then import</a>
+        <a href="<%= import_path('day_one') %>" class="btn btn-secondary">Open the Day One importer</a>
+      </div>
+    </header>
+
+    <section class="mt-16">
+      <h2 class="font-serif text-3xl text-primary">How to move your Day One journal</h2>
+      <ol class="mt-6 space-y-4 text-muted">
+        <li class="flex gap-4">
+          <span class="font-serif text-2xl text-accent leading-none">1</span>
+          <span>In Day One, export your journal as <strong class="text-primary">JSON</strong> and include media if you want photos.</span>
+        </li>
+        <li class="flex gap-4">
+          <span class="font-serif text-2xl text-accent leading-none">2</span>
+          <span>Create a Dabble Me account (PRO unlocks imports) and open
+            <a href="<%= import_path('day_one') %>" class="text-accent hover:text-primary underline">Entries → Import → Day One</a>.</span>
+        </li>
+        <li class="flex gap-4">
+          <span class="font-serif text-2xl text-accent leading-none">3</span>
+          <span>Upload the ZIP Day One created. Dabble Me imports your entries and emails you when it finishes.</span>
+        </li>
+      </ol>
+      <p class="mt-5 text-sm text-subtle">
+        Multiple Day One entries on the same calendar day are combined into one Dabble Me entry. Existing Dabble Me dates are left unchanged.
+      </p>
+    </section>
+
+    <section class="mt-16 overflow-x-auto card">
+      <table class="w-full text-left text-sm">
+        <thead class="border-b border-subtle">
+          <tr>
+            <th class="p-4 font-semibold text-primary">If you care about…</th>
+            <th class="p-4 font-semibold text-primary">Day One</th>
+            <th class="p-4 font-semibold text-primary">Dabble Me</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-subtle">
+          <tr>
+            <td class="p-4 font-medium text-primary">Daily writing habit</td>
+            <td class="p-4 text-muted">Native apps on Apple platforms and Android</td>
+            <td class="p-4 text-muted">Email prompts; reply to create an entry</td>
+          </tr>
+          <tr>
+            <td class="p-4 font-medium text-primary">Bringing your history</td>
+            <td class="p-4 text-muted">JSON / PDF / Markdown exports</td>
+            <td class="p-4 text-muted">Import Day One JSON ZIP (plus OhLife, Ahhlife, Trailmix)</td>
+          </tr>
+          <tr>
+            <td class="p-4 font-medium text-primary">Photos</td>
+            <td class="p-4 text-muted">Rich media in the Day One apps</td>
+            <td class="p-4 text-muted">One image per day (collage if several photos import)</td>
+          </tr>
+          <tr>
+            <td class="p-4 font-medium text-primary">AI / MCP</td>
+            <td class="p-4 text-muted">Official local MCP on Mac</td>
+            <td class="p-4 text-muted">Hosted remote MCP for ChatGPT and Claude</td>
+          </tr>
+          <tr>
+            <td class="p-4 font-medium text-primary">Best fit</td>
+            <td class="p-4 text-muted">People who love Day One’s native apps</td>
+            <td class="p-4 text-muted">People who want the habit to live in their inbox</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="mt-16">
+      <h2 class="font-serif text-3xl text-primary">Choose Dabble Me as a Day One alternative when…</h2>
+      <ul class="mt-5 space-y-3 text-muted">
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You want journaling reminders in email — and replies that become private entries.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You already have years in Day One and need a straightforward JSON ZIP import.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You use more than one device or OS and do not want the habit tied to a single app.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You want optional AI reflection through a remote MCP connection, not a local Mac server.</span></li>
+      </ul>
+    </section>
+
+    <section class="mt-14">
+      <h2 class="font-serif text-3xl text-primary">Stay with Day One when…</h2>
+      <ul class="mt-5 space-y-3 text-muted">
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>Day One’s native apps, multi-journal layout, and media features are central to how you write.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You prefer local MCP on a Mac over a hosted email-first journal.</span></li>
+        <li class="flex gap-3"><span aria-hidden="true" class="text-accent">✓</span><span>You do not want to change your daily capture workflow.</span></li>
+      </ul>
+    </section>
+
+    <section class="mt-14 card p-6 bg-accent/5 border-accent/20">
+      <h2 class="font-serif text-2xl text-primary">Comparing AI access separately?</h2>
+      <p class="mt-3 text-sm leading-relaxed text-muted">
+        If you are choosing between Dabble Me and Day One specifically for ChatGPT or Claude MCP setup,
+        read the focused comparison — it stays on remote vs. local AI architecture, not migration.
+      </p>
+      <a href="<%= day_one_ai_journaling_path %>" class="mt-4 inline-block text-accent hover:text-primary underline">
+        Dabble Me vs. Day One for AI journaling →
+      </a>
+    </section>
+
+    <section class="mt-16 card p-8 text-center">
+      <h2 class="font-serif text-3xl text-primary">Bring your Day One history with you</h2>
+      <p class="mt-3 text-muted">Sign up free, upgrade to PRO when you are ready to import, and keep the habit in your inbox.</p>
+      <div class="mt-6 flex flex-col sm:flex-row justify-center gap-3">
+        <a href="<%= new_user_registration_path %>" class="btn btn-primary">Create your account</a>
+        <a href="<%= import_path('day_one') %>" class="btn btn-secondary">Import Day One entries</a>
+      </div>
+    </section>
+  </div>
+</section>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -295,19 +295,15 @@ sample_entry = sample_entries.sample
         </p>
       </div>
 
-      <div class="card p-6 border-accent/30">
-        <div class="flex items-center gap-2 mb-4">
-          <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
-            <svg class="h-6 w-6 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-            </svg>
-          </div>
-          <span class="badge badge-accent dark:text-olive-800 text-xs">PRO</span>
+      <div class="card p-6">
+        <div class="w-12 h-12 rounded-lg bg-surface-elevated flex items-center justify-center mb-4">
+          <svg class="h-6 w-6 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+          </svg>
         </div>
-        <h3 class="font-semibold text-base text-primary font-sans">AI Connector</h3>
+        <h3 class="font-semibold text-base text-primary font-sans">Always Private</h3>
         <p class="mt-2 text-muted">
-          Optional AI connector for ChatGPT and Claude — you approve access, and nothing runs until you connect.
-          No social features. No sharing. No algorithms. Your journal stays yours.
+          No social features. No sharing. No algorithms. Optional AI connector for ChatGPT and Claude — you approve access, and nothing runs until you connect. Your journal stays yours.
         </p>
       </div>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -295,15 +295,19 @@ sample_entry = sample_entries.sample
         </p>
       </div>
 
-      <div class="card p-6">
-        <div class="w-12 h-12 rounded-lg bg-surface-elevated flex items-center justify-center mb-4">
-          <svg class="h-6 w-6 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-          </svg>
+      <div class="card p-6 border-accent/30">
+        <div class="flex items-center gap-2 mb-4">
+          <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+            <svg class="h-6 w-6 text-accent" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+            </svg>
+          </div>
+          <span class="badge badge-accent dark:text-olive-800 text-xs">PRO</span>
         </div>
-        <h3 class="font-semibold text-base text-primary font-sans">Always Private</h3>
+        <h3 class="font-semibold text-base text-primary font-sans">Secure AI Connector</h3>
         <p class="mt-2 text-muted">
-          No artitifial intelligence. No social features. No sharing. No algorithms. Your journal stays yours.
+          Optional MCP for ChatGPT and Claude — you approve access, and nothing runs until you connect.
+          No social features. No sharing. No algorithms. Your journal stays yours.
         </p>
       </div>
 
@@ -550,7 +554,7 @@ sample_entry = sample_entries.sample
             <svg class="h-5 w-5 text-accent shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
             </svg>
-            <span class="text-muted">MCP (Claude &amp; compatible apps)</span>
+            <span class="text-muted">Secure AI connector (MCP)</span>
           </li>
           <li class="flex items-start gap-3">
             <svg class="h-5 w-5 text-accent shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -304,9 +304,9 @@ sample_entry = sample_entries.sample
           </div>
           <span class="badge badge-accent dark:text-olive-800 text-xs">PRO</span>
         </div>
-        <h3 class="font-semibold text-base text-primary font-sans">Secure AI Connector</h3>
+        <h3 class="font-semibold text-base text-primary font-sans">AI Connector</h3>
         <p class="mt-2 text-muted">
-          Optional MCP for ChatGPT and Claude — you approve access, and nothing runs until you connect.
+          Optional AI connector for ChatGPT and Claude — you approve access, and nothing runs until you connect.
           No social features. No sharing. No algorithms. Your journal stays yours.
         </p>
       </div>
@@ -554,7 +554,7 @@ sample_entry = sample_entries.sample
             <svg class="h-5 w-5 text-accent shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
             </svg>
-            <span class="text-muted">Secure AI connector (MCP)</span>
+            <span class="text-muted">AI connector</span>
           </li>
           <li class="flex items-start gap-3">
             <svg class="h-5 w-5 text-accent shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">

--- a/app/views/welcome/ohlife_alternative.html.erb
+++ b/app/views/welcome/ohlife_alternative.html.erb
@@ -33,7 +33,7 @@
             <svg class="h-5 w-5 text-accent flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
             </svg>
-            <span class="text-muted">Import OhLife / Ahhlife / Trailmix.life Entries</span>
+            <span class="text-muted">Import OhLife / Day One / Ahhlife / Trailmix.life Entries</span>
           </li>
           <li class="flex items-start gap-3">
             <svg class="h-5 w-5 text-accent flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
   get 'support',                        to: 'welcome#support'
   get 'mcp-server',                     to: 'welcome#mcp_server', as: :mcp_server_docs
   get 'dabble-me-vs-day-one-ai-journaling', to: 'welcome#day_one_ai_journaling', as: :day_one_ai_journaling
+  get 'day-one-alternative',            to: 'welcome#day_one_alternative', as: :day_one_alternative
   get 'best-journaling-apps-with-mcp',  to: 'welcome#best_journaling_apps_with_mcp', as: :best_journaling_apps_with_mcp
   match 'mcp', to: 'mcp#invoke', via: %i[get post], format: :json, as: :mcp
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,8 @@
 Inspiration.create(category: 'Seed', body: 'Seeded into database')
 Inspiration.create(category: 'OhLife', body: 'Imported from OhLife')
 Inspiration.create(category: 'Ahhlife', body: 'Imported from Ahhlife')
+Inspiration.create(category: 'Day One', body: 'Imported from Day One')
+Inspiration.create(category: 'Trailmix', body: 'Imported from Trailmix')
 (1..30).each do |i|
   Inspiration.create(category: ['Question', 'Quote', 'Tip'].sample, body: Faker::Hipster.sentence)
 end

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,6 +6,7 @@
 
 - [Dabble Me MCP Server](https://dabble.me/mcp-server): Supported clients, setup, OAuth authentication, permissions, live tool reference, technical metadata, privacy notes, and example prompts. <!-- pragma: allowlist secret -->
 - [Dabble Me vs. Day One for AI journaling](https://dabble.me/dabble-me-vs-day-one-ai-journaling): A balanced remote-vs-local MCP comparison. <!-- pragma: allowlist secret -->
+- [Day One alternative](https://dabble.me/day-one-alternative): Import a Day One JSON export into Dabble Me and journal by email. <!-- pragma: allowlist secret -->
 - [Best journaling apps with MCP / Claude & ChatGPT Connectors](https://dabble.me/best-journaling-apps-with-mcp): Evaluation criteria, example prompts, and current vendor-supported options. <!-- pragma: allowlist secret -->
 - [Privacy policy](https://dabble.me/privacy): How Dabble Me stores journal data and handles connected apps. <!-- pragma: allowlist secret -->
 - [Support](https://dabble.me/support): Product FAQs. <!-- pragma: allowlist secret -->

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -22,9 +22,15 @@
 </url>
 <url>
   <loc>https://dabble&#46;me/dabble-me-vs-day-one-ai-journaling</loc>
-  <lastmod>2026-07-23</lastmod>
+  <lastmod>2026-08-02</lastmod>
   <changefreq>monthly</changefreq>
   <priority>0.7</priority>
+</url>
+<url>
+  <loc>https://dabble&#46;me/day-one-alternative</loc>
+  <lastmod>2026-08-02</lastmod>
+  <changefreq>monthly</changefreq>
+  <priority>0.8</priority>
 </url>
 <url>
   <loc>https://dabble&#46;me/best-journaling-apps-with-mcp</loc>

--- a/spec/controllers/import_controller_spec.rb
+++ b/spec/controllers/import_controller_spec.rb
@@ -51,6 +51,45 @@ RSpec.describe ImportController, type: :controller do
     end
   end
 
+  describe "PUT #update day_one" do
+    it "rejects non-zip uploads for day_one" do
+      sign_in paid_user
+      file = Tempfile.new(["not", ".json"])
+      file.write("{}")
+      file.rewind
+      upload = Rack::Test::UploadedFile.new(file.path, "application/json", original_filename: "Journal.json")
+
+      put :update, params: { type: "day_one", zip_file: upload }
+
+      expect(response).to redirect_to(import_path(type: "day_one"))
+      expect(flash[:alert]).to match(/Only \.zip/)
+      expect(ImportDayOneJob).not_to have_been_enqueued
+    ensure
+      file.close!
+    end
+
+    it "enqueues ImportDayOneJob with a path under tmp/imports" do
+      sign_in paid_user
+      file = Tempfile.new(["journal", ".zip"])
+      file.write("PK\x03\x04fake")
+      file.rewind
+      upload = Rack::Test::UploadedFile.new(file.path, "application/zip", original_filename: "Journal.zip")
+
+      expect {
+        put :update, params: { type: "day_one", zip_file: upload }
+      }.to have_enqueued_job(ImportDayOneJob).with { |_user_id, path|
+        expect(path).to start_with(ImportUploadStore::BASE_DIR.to_s)
+        expect(path).to include("/day_one/")
+        expect(File.basename(path)).to eq("upload.zip")
+      }
+
+      expect(response).to redirect_to(entries_path)
+      expect(flash[:notice]).to match(/Day One import has started/)
+    ensure
+      file.close!
+    end
+  end
+
   describe "POST #process_ohlife_images" do
     it "rejects non-zip uploads" do
       sign_in paid_user

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -72,6 +72,9 @@ describe 'Pages' do
     visit day_one_ai_journaling_path
 
     expect(page).to have_title 'Dabble Me vs. Day One for AI Journaling and MCP — Dabble me.'
+    expect(page).to have_content 'Remote connector vs. local connector'
+    expect(page).to have_content 'Mobile and desktop ChatGPT / Claude apps'
+    expect(page).to have_content 'Desktop Mac setup — not a mobile-first connector'
     expect(page).to have_content 'Remote Streamable HTTP'
     expect(page).to have_content 'Local stdio process'
     expect(page).to have_link('official MCP guide')

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -75,6 +75,21 @@ describe 'Pages' do
     expect(page).to have_content 'Remote Streamable HTTP'
     expect(page).to have_content 'Local stdio process'
     expect(page).to have_link('official MCP guide')
+    expect(page).to have_link('Day One alternative & journal import', href: day_one_alternative_path)
+  end
+
+  it 'publishes a Day One alternative page focused on import and email journaling' do
+    visit day_one_alternative_path
+
+    expect(page).to have_title 'Day One Alternative: Import Your Journal into Dabble Me — Dabble me.'
+    expect(page).to have_content 'Import Day One. Journal by email.'
+    expect(page).to have_content 'export your journal as JSON'
+    expect(page).to have_link('Open the Day One importer', href: import_path('day_one'))
+    expect(page).to have_link('Dabble Me vs. Day One for AI journaling', href: day_one_ai_journaling_path)
+    expect(page).to have_css('script[type="application/ld+json"]', visible: false)
+
+    description = page.find('meta[name="description"]', visible: false)['content']
+    expect(description).to include('Day One alternative')
   end
 
   it 'publishes a guide to journaling apps with MCP' do

--- a/spec/jobs/import_day_one_job_spec.rb
+++ b/spec/jobs/import_day_one_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ImportDayOneJob, type: :job do
+  include_context "has all objects"
+  include ActiveJob::TestHelper
+
+  after { FileUtils.rm_rf(ImportUploadStore::BASE_DIR) }
+
+  it "imports entries, emails the user, and cleans up the upload" do
+    dir = ImportUploadStore::BASE_DIR.join("day_one", paid_user.user_key, SecureRandom.uuid)
+    FileUtils.mkdir_p(dir)
+    zip_path = dir.join("upload.zip")
+
+    require "zip"
+    Zip::File.open(zip_path, create: true) do |zip|
+      zip.get_output_stream("Journal.json") do |f|
+        f.write({
+          "entries" => [
+            {
+              "creationDate" => "2018-05-05T10:00:00Z",
+              "timeZone" => "UTC",
+              "text" => "Job import works"
+            }
+          ]
+        }.to_json)
+      end
+    end
+
+    expect {
+      described_class.perform_now(paid_user.id, zip_path.to_s)
+    }.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+
+    entry = paid_user.existing_entry("2018-05-05")
+    expect(entry.body).to include("Job import works")
+    expect(entry.inspiration.category).to eq("Day One")
+    expect(File.exist?(dir)).to eq(false)
+  end
+end

--- a/spec/requests/mcp_public_discovery_spec.rb
+++ b/spec/requests/mcp_public_discovery_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Public MCP discovery', type: :request do
 
     expect(sitemap).to include("#{public_url}/mcp-server")
     expect(sitemap).to include("#{public_url}/dabble-me-vs-day-one-ai-journaling")
+    expect(sitemap).to include("#{public_url}/day-one-alternative")
     expect(sitemap).to include("#{public_url}/best-journaling-apps-with-mcp")
     expect(robots).to include("Sitemap: #{public_url}/sitemap.xml")
   end

--- a/spec/services/day_one_importer_spec.rb
+++ b/spec/services/day_one_importer_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "zip"
+
+RSpec.describe DayOneImporter do
+  include_context "has all objects"
+
+  def build_zip(entries:, photos: {})
+    path = Rails.root.join("tmp", "day_one_spec_#{SecureRandom.hex}.zip")
+    FileUtils.mkdir_p(File.dirname(path))
+    Zip::File.open(path, create: true) do |zip|
+      zip.get_output_stream("Journal.json") do |f|
+        f.write(JSON.pretty_generate("entries" => entries))
+      end
+      photos.each do |filename, bytes|
+        zip.get_output_stream("photos/#{filename}") { |f| f.write(bytes) }
+      end
+    end
+    path.to_s
+  end
+
+  # 1x1 JPEG
+  let(:tiny_jpeg) do
+    Base64.decode64("/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAGfAP/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAQUCf//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQMBAT8Bf//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQIBAT8Bf//Z")
+  end
+
+  after do
+    Dir.glob(Rails.root.join("tmp", "day_one_spec_*.zip")).each { |f| FileUtils.rm_f(f) }
+  end
+
+  describe "#import!" do
+    it "imports markdown entries with the Day One inspiration tag" do
+      zip = build_zip(entries: [
+        {
+          "creationDate" => "2020-06-15T18:30:00Z",
+          "timeZone" => "America/Los_Angeles",
+          "text" => "# Hello\n\nThis is **bold** and a photo ![](dayone-moment://ABC123)."
+        }
+      ])
+
+      result = described_class.new(user: paid_user, zip_path: zip).import!
+
+      expect(result.imported).to eq(1)
+      expect(result.errors).to be_empty
+      entry = paid_user.entries.find_by("date >= ? AND date < ?", Date.new(2020, 6, 15), Date.new(2020, 6, 16))
+      expect(entry).to be_present
+      # 18:30 UTC on 2020-06-15 is 11:30 PDT → still June 15
+      expect(entry.date.to_date).to eq(Date.new(2020, 6, 15))
+      expect(entry.body).to include("<strong>bold</strong>")
+      expect(entry.body).to include("Hello")
+      expect(entry.body).not_to include("dayone-moment")
+      expect(entry.inspiration.category).to eq("Day One")
+    end
+
+    it "merges multiple Day One entries on the same local calendar day" do
+      zip = build_zip(entries: [
+        {
+          "creationDate" => "2021-01-02T08:00:00Z",
+          "timeZone" => "UTC",
+          "text" => "Morning thoughts"
+        },
+        {
+          "creationDate" => "2021-01-02T20:00:00Z",
+          "timeZone" => "UTC",
+          "text" => "Evening thoughts"
+        }
+      ])
+
+      result = described_class.new(user: paid_user, zip_path: zip).import!
+
+      expect(result.imported).to eq(1)
+      entry = paid_user.existing_entry("2021-01-02")
+      expect(entry.body).to include("Morning thoughts")
+      expect(entry.body).to include("Evening thoughts")
+      expect(entry.body).to include("<hr>")
+    end
+
+    it "skips dates that already have a Dabble Me entry" do
+      paid_user.entries.create!(date: Date.new(2019, 3, 1), body: "<p>Existing</p>")
+      zip = build_zip(entries: [
+        {
+          "creationDate" => "2019-03-01T12:00:00Z",
+          "timeZone" => "UTC",
+          "text" => "Should not import"
+        }
+      ])
+
+      result = described_class.new(user: paid_user, zip_path: zip).import!
+
+      expect(result.imported).to eq(0)
+      expect(result.skipped.join).to match(/already exists/)
+      expect(paid_user.existing_entry("2019-03-01").body).to include("Existing")
+    end
+
+    it "attaches a single photo when present" do
+      md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      zip = build_zip(
+        entries: [
+          {
+            "creationDate" => "2022-04-01T12:00:00Z",
+            "timeZone" => "UTC",
+            "text" => "With photo",
+            "photos" => [
+              { "identifier" => "ID1", "md5" => md5, "type" => "jpeg", "orderInEntry" => 0 }
+            ]
+          }
+        ],
+        photos: { "#{md5}.jpeg" => tiny_jpeg }
+      )
+
+      allow_any_instance_of(ImageUploader).to receive(:cache!)
+      allow_any_instance_of(ImageUploader).to receive(:store!)
+
+      result = described_class.new(user: paid_user, zip_path: zip).import!
+
+      expect(result.imported).to eq(1)
+      expect(result.errors).to be_empty
+      entry = paid_user.existing_entry("2022-04-01")
+      expect(entry.body).to include("With photo")
+      expect(entry.image_error).to be_blank
+    end
+
+    it "rejects ZIPs without a journal JSON file" do
+      path = Rails.root.join("tmp", "day_one_spec_empty_#{SecureRandom.hex}.zip")
+      Zip::File.open(path, create: true) do |zip|
+        zip.get_output_stream("readme.txt") { |f| f.write("no json here") }
+      end
+
+      expect {
+        described_class.new(user: paid_user, zip_path: path.to_s).import!
+      }.to raise_error(ArgumentError, /No JSON/)
+    end
+  end
+end

--- a/spec/services/import_upload_store_spec.rb
+++ b/spec/services/import_upload_store_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe ImportUploadStore do
       expect(File.stat(path).mode & 0o777).to eq(0o600)
     end
 
+    it "stores day_one ZIP outside public/ with a random filename" do
+      zip = Tempfile.new(["journal", ".zip"], tmpdir)
+      zip.write("PK\x03\x04")
+      zip.rewind
+      upload = uploaded_file(filename: "Journal.zip", content_type: "application/zip", tempfile: zip)
+
+      path = described_class.store!(uploaded_file: upload, user_key: user_key, kind: "day_one")
+
+      expect(path).to start_with(ImportUploadStore::BASE_DIR.to_s)
+      expect(path).to include("/day_one/")
+      expect(File.basename(path)).to eq("upload.zip")
+      expect(File.stat(path).mode & 0o777).to eq(0o600)
+    end
+
     it "rejects non-json trailmix uploads" do
       html = Tempfile.new(["xss", ".html"], tmpdir)
       html.write("<script>alert(1)</script>")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
PRO users can import Day One journal exports (JSON ZIP) at `/entries/import/day_one`, with SEO for migration intent on a dedicated landing page.

## Importer
- Async `ImportDayOneJob` (same pattern as Trailmix / OhLife photos)
- Parses journal `.json` files; markdown → HTML; strips `dayone-moment://` embeds
- Dates from `creationDate` + timezone; same-day merge; skips existing Dabble dates
- One image per day (or collage); Inspiration category `Day One`
- Preserves import source tags on save (`Entry#associate_inspiration`)

## SEO
- New `/day-one-alternative` page for “Day One alternative / import” intent
- MCP comparison page stays AI-focused; light cross-link to the alternative page
- Sitemap, `llms.txt`, and MCP guide Day One section updated

## Marketing
- Homepage + PRO features: “Always Private / no AI” merged into **AI Connector** (optional ChatGPT/Claude connection; still no social/sharing/algorithms)
- Logged-in app footer: **AI Connector**
- Search page callout markets asking ChatGPT/Claude about your journal
- Plain-language “AI connector” on product surfaces; MCP kept on technical docs pages

## Tests
Importer + welcome/discovery specs passing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc414-6827-7f80-9eb2-1b7945d48650?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc414-6827-7f80-9eb2-1b7945d48650&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

