### PR TITLE
Preserve intentional email indentation

### DIFF
--- a/app/lib/email_processor.rb
+++ b/app/lib/email_processor.rb
@@ -15,9 +15,12 @@ class EmailProcessor
     @bcc = email.bcc
     @subject = to_utf8(email.subject)
     @stripped_html = email.vendor_specific.try(:[], :stripped_html)
-    @body = clean_message(email.body).presence || "No entry provided."
+    @griddler_body = to_utf8(email.body&.dup)
+    @raw_html = email.raw_html
+    @body = clean_message(@griddler_body&.dup).presence || "No entry provided."
 
     @html = clean_html_version(@stripped_html)
+    @authored_indentation_html = clean_authored_indentation_html(@raw_html, @griddler_body)
     @message_id = email.headers&.dig("Message-ID")&.gsub("<", "")&.gsub(">", "")
 
     @raw_body = to_utf8(email.raw_body)
@@ -108,7 +111,11 @@ class EmailProcessor
       date = parse_subject_for_date(@subject)
       existing_entry = @user.existing_entry(date.to_s)
       inspiration_id = parse_body_for_inspiration_id(@raw_body)
-      @body = preferred_pro_body if @user.is_pro?
+      if @user.is_pro?
+        @body = preferred_pro_body
+      elsif @user.is_free? && @authored_indentation_html.present?
+        @body = clean_message(without_leading_quote_markers(@griddler_body)).presence || @body
+      end
 
       if existing_entry.present?
         existing_entry.original_email = @inbound_email_params
@@ -414,7 +421,48 @@ class EmailProcessor
     fragment.text.unicode_normalize(:nfkc).gsub(/\s+/, ' ').strip
   end
 
+  def clean_authored_indentation_html(raw_html, griddler_body)
+    return unless raw_html.present? && griddler_body.present?
+
+    has_quote_markers = griddler_body.lines.any? { |line| line.match?(/\A[[:blank:]]*>/) }
+    fragment = Nokogiri::HTML5.fragment(raw_html)
+    fragment.css('.gmail_quote, .gmail_signature').remove
+    blockquote_count = fragment.css('blockquote').count
+    unsafe_content = unsafe_raw_html?(fragment)
+    cleaned_html = clean_html_version(fragment.to_html) if has_quote_markers && blockquote_count.positive? && !unsafe_content
+    text_matches = cleaned_html.present? &&
+                   normalized_visible_text(cleaned_html) == normalized_unquoted_plain_text(griddler_body)
+    accepted = has_quote_markers && blockquote_count.positive? && !unsafe_content && text_matches
+
+    cleaned_html if accepted
+  end
+
+  def normalized_unquoted_plain_text(body)
+    without_leading_quote_markers(body)
+        .unicode_normalize(:nfkc)
+        .gsub(/\s+/, ' ')
+        .strip
+  end
+
+  def without_leading_quote_markers(body)
+    body.to_s.lines.map { |line| line.sub(/\A[[:blank:]]*(?:>[[:blank:]]*)+/, '') }.join
+  end
+
+  def unsafe_raw_html?(fragment)
+    unsafe_elements = %w[script iframe object embed form input button textarea select option link meta base svg math]
+    return true if fragment.css(unsafe_elements.join(',')).any?
+
+    fragment.css('*').any? do |node|
+      node.attribute_nodes.any? do |attribute|
+        attribute.name.match?(/\Aon/i) ||
+          (%w[href src xlink:href formaction].include?(attribute.name.downcase) &&
+            attribute.value.match?(/\A\s*(?:javascript|vbscript|data):/i))
+      end
+    end
+  end
+
   def preferred_pro_body
+    return @authored_indentation_html if @authored_indentation_html.present?
     return @body unless @html.present?
 
     plain_text = normalized_visible_text(@body)

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -89,6 +89,31 @@ describe 'Day Entries' do
       expect(rendered_entry).not_to have_text('Sender signature')
     end
 
+    it 'renders Gmail-authored indentation as a blockquote without quote history' do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\n> Second intentionally indented paragraph",
+        raw_html: '<div dir="ltr"><div>First paragraph</div><blockquote style="margin:0 0 0 40px;border:none;padding:0"><div>Second intentionally indented paragraph</div></blockquote></div><div class="gmail_quote"><div>On Aug 2, 2026, Dabble Me wrote:</div><blockquote><div>Actual quoted history</div></blockquote></div>',
+        vendor_specific: {
+          stripped_html: '<div>First paragraph</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+      processed_entry = paid_user.entries.reload.first
+
+      sign_in paid_user
+      visit day_entry_url(year: processed_entry.date.year, month: processed_entry.date.month, day: processed_entry.date.day)
+
+      rendered_entry = page.find('.s-scrollable')
+      expect(rendered_entry).to have_text('First paragraph')
+      expect(rendered_entry.find('blockquote')).to have_text('Second intentionally indented paragraph')
+      expect(rendered_entry).not_to have_text('Actual quoted history')
+      expect(rendered_entry).not_to have_text('Dabble Me wrote')
+    end
+
     it 'should show an entry stored at a non-midnight datetime' do
       sign_in user
       entry.update_columns(date: Time.utc(2026, 7, 17, 15, 30, 0), body: '<p>Afternoon journal entry</p>')

--- a/spec/models/email_processor_spec.rb
+++ b/spec/models/email_processor_spec.rb
@@ -56,7 +56,158 @@ describe EmailProcessor do
       expect(paid_user.entries.reload.first.body).to eq("<p>I am great</p><p>Here's a link: <a href=\"https://www.google.com\" target=\"_blank\">https://www.google.com</a></p>")
     end
 
-    it "recovers a complete paid entry when Mailgun stripped HTML loses nested authored paragraphs" do
+    it "preserves a trailing Gmail-authored indentation block" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\n> Second intentionally indented paragraph",
+        raw_html: '<div dir="ltr"><div>First paragraph</div><blockquote style="margin:0 0 0 40px;border:none;padding:0"><div>Second intentionally indented paragraph</div></blockquote></div>',
+        vendor_specific: {
+          stripped_html: '<div>First paragraph</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq(
+        '<div><div>First paragraph</div><blockquote><div>Second intentionally indented paragraph</div></blockquote></div>'
+      )
+    end
+
+    it "preserves trailing Gmail-authored indentation for a free user as plain formatting" do
+      user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\n> Second intentionally indented paragraph",
+        raw_html: '<div dir="ltr"><div>First paragraph</div><blockquote style="margin:0 0 0 40px;border:none;padding:0"><div>Second intentionally indented paragraph</div></blockquote></div><div class="gmail_quote"><div>On Aug 2, 2026, Dabble Me wrote:</div><blockquote><div>Actual quoted history</div></blockquote></div>',
+        vendor_specific: {
+          stripped_html: '<div>First paragraph</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(user.entries.reload.first.body).to eq(
+        'First paragraph<br><br>Second intentionally indented paragraph'
+      )
+    end
+
+    it "preserves a whole Gmail-authored indented entry with multiple quote lines" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "> First indented paragraph\n>\n> Second indented paragraph",
+        raw_html: '<blockquote style="margin:0 0 0 40px;border:none;padding:0"><div>First indented paragraph</div><div><br></div><div>Second indented paragraph</div></blockquote>',
+        vendor_specific: {
+          stripped_html: nil
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq(
+        '<blockquote><div>First indented paragraph</div><br><div>Second indented paragraph</div></blockquote>'
+      )
+    end
+
+    it "preserves normal text after a Gmail-authored indentation block" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "Before indentation\n\n> Intentionally indented\n\nAfter indentation",
+        raw_html: '<div dir="ltr"><div>Before indentation</div><blockquote style="margin:0 0 0 40px;border:none;padding:0"><div>Intentionally indented</div></blockquote><div>After indentation</div></div>',
+        vendor_specific: {
+          stripped_html: '<div>Before indentation</div><div>After indentation</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq(
+        '<div><div>Before indentation</div><blockquote><div>Intentionally indented</div></blockquote><div>After indentation</div></div>'
+      )
+    end
+
+    it "preserves authored indentation while excluding actual Gmail quote history" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\n> Authored indentation",
+        raw_html: '<div dir="ltr"><div>First paragraph</div><blockquote style="margin:0 0 0 40px;border:none;padding:0"><div>Authored indentation</div></blockquote></div><div class="gmail_quote"><div>On Aug 2, 2026, Dabble Me wrote:</div><blockquote><div>Actual quoted history</div></blockquote></div>',
+        vendor_specific: {
+          stripped_html: '<div>First paragraph</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      saved_body = paid_user.entries.reload.first.body
+      expect(saved_body).to eq(
+        '<div><div>First paragraph</div><blockquote><div>Authored indentation</div></blockquote></div>'
+      )
+      expect(saved_body).not_to include('Actual quoted history')
+      expect(saved_body).not_to include('Dabble Me wrote')
+    end
+
+    it "rejects a generic raw quote when an attribution reveals quoted history" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "New response\n\n> Previous entry",
+        raw_html: '<div>New response</div><div>On Aug 2, 2026, Someone wrote:</div><blockquote><div>Previous entry</div></blockquote>',
+        vendor_specific: {
+          stripped_html: '<div>New response</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq('<div>New response</div>')
+    end
+
+    it "falls back safely when raw indentation HTML contains active content" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\n> Second paragraph",
+        raw_html: '<div>First paragraph</div><blockquote style="margin:0 0 0 40px;border:none;padding:0" onclick="alert(1)"><div>Second paragraph</div></blockquote>',
+        vendor_specific: {
+          stripped_html: '<div>First paragraph</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      saved_body = paid_user.entries.reload.first.body
+      expect(saved_body).to eq('<div>First paragraph</div>')
+      expect(saved_body).not_to include('onclick')
+    end
+
+    it "falls back safely when raw indentation text does not match the Griddler body" do
+      paid_user.entries.destroy_all
+      email = FactoryBot.build(
+        :email,
+        to: [{ token: paid_user.user_key, host: ENV['SMTP_DOMAIN'], email: "#{paid_user.user_key}@#{ENV['SMTP_DOMAIN']}"}],
+        body: "First paragraph\n\n> Expected second paragraph",
+        raw_html: '<div>First paragraph</div><blockquote style="margin:0 0 0 40px;border:none;padding:0"><div>Different second paragraph</div></blockquote>',
+        vendor_specific: {
+          stripped_html: '<div>First paragraph</div>'
+        }
+      )
+
+      EmailProcessor.new(email).process
+
+      expect(paid_user.entries.reload.first.body).to eq('<div>First paragraph</div>')
+    end
+
+    it "keeps the complete plain fallback for #144 malformed authored content inside .gmail_quote" do
       paid_user.entries.destroy_all
       email = FactoryBot.build(
         :email,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- distinguish Gmail-authored indentation from actual `.gmail_quote` reply history
- recover sanitized `<blockquote>` markup only when it exactly matches Griddler’s already-isolated plain reply
- remove Gmail history and signature containers before validating recovered indentation
- preserve indented text for free users as plain formatting
- reject attributed quotes, mismatched text, and active raw HTML
- retain the complete uniformly spaced fallback from the prior Mailgun fix

## Verification
- `bundle exec rspec spec/models/email_processor_spec.rb spec/features/entries_spec.rb` — 54 examples, 0 failures
- `bundle exec rspec` — 252 examples, 0 failures, 1 expected pending
- CI `vm-job` and CodeFactor pass
- manually processed a reply containing authored indentation plus actual outbound history; indentation renders and history/signature remain absent

<a href="https://cursor.com/agents/bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintentional_email_indentation_preserved.mp4"><img src="https://cursor.com/artifacts/c/art-bbf45196-17be-4ac1-95de-29fc00dc984e" alt="intentional_email_indentation_preserved.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

