### PR TITLE
Clarify entry deletion on edit page

### DIFF
--- a/app/assets/stylesheets/entries.scss
+++ b/app/assets/stylesheets/entries.scss
@@ -102,6 +102,11 @@ a.s-delete {
   }
 }
 
+.delete-entry-action {
+  margin-top: 15px;
+  text-align: center;
+}
+
 .s-unsubscribe {
   -webkit-appearance: none;
   background: none;

--- a/app/views/entries/edit.html.haml
+++ b/app/views/entries/edit.html.haml
@@ -59,7 +59,7 @@
           = f.submit "Update Entry", class: "form-control btn btn-primary"
 
       .delete-entry-action
-        = link_to "delete this entry", entry_path(@entry), class: "s-delete", method: :delete, data: { confirm: 'Are you sure you want to delete this entry? There is no undo.' }
+        = link_to "Delete Entry", entry_path(@entry), class: "s-delete", method: :delete, data: { confirm: 'Are you sure you want to delete this entry? There is no undo.' }
 
 :javascript
   var summer_note = $('#entry_entry');

--- a/app/views/entries/edit.html.haml
+++ b/app/views/entries/edit.html.haml
@@ -15,9 +15,6 @@
         -if @entry.inspiration.present?
           .float-left.s-edit-entry{rel: "popover", title: "#{@entry.inspiration.inspired_by}", data: { content: "#{@entry.inspiration.body.html_safe}" }}
             %i.fa.fa-lightbulb-o
-        .float-right.s-edit-entry{rel: "tooltip", title: "Delete this entry"}
-          = link_to entry_path(@entry), class: "s-delete", method: :delete, data: { confirm: 'Are you sure you want to delete this entry? There is no undo.' } do
-            %i.fa.fa-trash
         %h2= @entry.date_format_short
         %h3
           %span
@@ -60,6 +57,9 @@
 
         %div
           = f.submit "Update Entry", class: "form-control btn btn-primary"
+
+      .delete-entry-action
+        = link_to "delete this entry", entry_path(@entry), class: "s-delete", method: :delete, data: { confirm: 'Are you sure you want to delete this entry? There is no undo.' }
 
 :javascript
   var summer_note = $('#entry_entry');

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -146,7 +146,7 @@ describe 'Day Entries' do
       sign_in paid_user
       visit edit_entry_url(paid_entry)
 
-      delete_link = page.find('form + .delete-entry-action a.s-delete', text: 'delete this entry')
+      delete_link = page.find('form + .delete-entry-action a.s-delete', text: 'Delete Entry')
       expect(delete_link['data-method']).to eq('delete')
       expect(delete_link['data-confirm']).to eq('Are you sure you want to delete this entry? There is no undo.')
       expect(page).not_to have_css('.s-entry-date .fa-trash')

--- a/spec/features/entries_spec.rb
+++ b/spec/features/entries_spec.rb
@@ -141,4 +141,16 @@ describe 'Day Entries' do
     end
   end
 
+  describe 'edit' do
+    it 'shows a clear delete link below the update button' do
+      sign_in paid_user
+      visit edit_entry_url(paid_entry)
+
+      delete_link = page.find('form + .delete-entry-action a.s-delete', text: 'delete this entry')
+      expect(delete_link['data-method']).to eq('delete')
+      expect(delete_link['data-confirm']).to eq('Are you sure you want to delete this entry? There is no undo.')
+      expect(page).not_to have_css('.s-entry-date .fa-trash')
+    end
+  end
+
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the ambiguous trash icon from the entry edit header
- add a red “Delete Entry” text link centered directly below the Update Entry button
- retain the existing irreversible-action confirmation
- add feature coverage for label, placement, delete method, confirmation, and icon removal

## Verification
- `bundle exec rspec spec/features/entries_spec.rb` — 11 examples, 0 failures
- CI `vm-job` and CodeFactor pass
- verified the final capitalization and confirmation flow at a 390×844 mobile viewport; canceling leaves the entry intact

<a href="https://cursor.com/agents/bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_delete_entry_label.mp4"><img src="https://cursor.com/artifacts/c/art-df9a75f5-802c-4b4e-820a-700d260b2b4f" alt="mobile_delete_entry_label.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc1fe-7d31-71a1-b1d5-7fb6ecb52b44&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

